### PR TITLE
Add more data to context. Fixes #5.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -75,7 +75,7 @@ class Mali extends Emitter {
     if (this.load) {
       let descriptor = gi(this.proto)
       if (!descriptor) {
-        throw new Error(String.raw `Error parsing protocol buffer`)
+        throw new Error(String.raw`Error parsing protocol buffer`)
       }
       let names = descriptor.serviceNames()
       if (_.isString(name)) {
@@ -88,12 +88,8 @@ class Mali extends Emitter {
         const service = client ? client.service : null
         if (service) {
           this.services[n] = service
-          this.methods[n] = {}
           this.middleware[n] = []
-          const methods = descriptor.methods(n)
-          methods.forEach(m => {
-            this.methods[n][_.camelCase(m.name)] = m
-          })
+          this.methods[n] = mu.getMethodDescriptorsLoad(n, service, descriptor)
         }
       })
     } else if (_.isObject(this.proto)) {
@@ -108,7 +104,7 @@ class Mali extends Emitter {
         if (_.isObject(v) && !_.isFunction(v) && names.indexOf(n) >= 0) {
           this.services[n] = v
           this.middleware[n] = []
-          this.methods[n] = mu.getMethodDescriptors(v)
+          this.methods[n] = mu.getMethodDescriptorsProto(n, v)
         }
       })
     }
@@ -136,7 +132,7 @@ class Mali extends Emitter {
    *
    * @example <caption>Define handler with middleware for rpc function 'fn2'</caption>
    * app.use('fn2', mw1, mw2, fn2)
-   * 
+   *
    * @example <caption>Define handler with middleware for rpc function 'fn2' in service 'Service2'</caption>
    * app.use('Service2', 'fn2', mw1, mw2, fn2)
    *
@@ -210,16 +206,16 @@ class Mali extends Emitter {
         }
       }
       if (!this.services[serviceName]) {
-        throw new Error(String.raw `Unknown service ${serviceName}`)
+        throw new Error(String.raw`Unknown service ${serviceName}`)
       }
       if (!this.handlers[serviceName]) {
         this.handlers[serviceName] = {}
       }
       if (this.handlers[serviceName][name]) {
-        throw new Error(String.raw `Handler for ${name} already defined for service ${serviceName}`)
+        throw new Error(String.raw`Handler for ${name} already defined for service ${serviceName}`)
       }
       if (!this.methods[serviceName][name]) {
-        throw new Error(String.raw `Unknown method: ${name} for service ${serviceName}`)
+        throw new Error(String.raw`Unknown method: ${name} for service ${serviceName}`)
       }
       this.handlers[serviceName][name] = _.concat(this.middleware[serviceName], fns)
     }

--- a/lib/run.js
+++ b/lib/run.js
@@ -92,14 +92,19 @@ function onerror (err, ctx) {
 
 module.exports = function exec (ctx, fn) {
   const call = ctx.call
-  const name = ctx.descriptor.name
+  const { name, fullName, service } = ctx.descriptor
+  const packageName = ctx.descriptor.package
   const type = getCallType(ctx)
   const appCtx = ctx.app.context
+
   const common = {
     type,
-    call,
     name,
+    fullName,
+    service,
+    package: packageName,
     metadata: call.metadata,
+    call,
     app: ctx.app
   }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,12 +49,16 @@ exports.getMethodDescriptorsProto = function (serviceName, service) {
 exports.getMethodDescriptorsLoad = function (serviceName, service, descriptor) {
   const r = {}
   const methods = descriptor.methods(serviceName)
-  const packageName = service.parent.name
+  let packageName = ''
+  if (service && service.parent && service.parent.name) {
+    packageName = service.parent.name
+  }
   methods.forEach(m => {
     r[_.camelCase(m.name)] = m
+    r[_.camelCase(m.name)].name = _.upperFirst(m.name)
     r[_.camelCase(m.name)].package = packageName
     r[_.camelCase(m.name)].service = serviceName
-    r[_.camelCase(m.name)].fullName = getFullName('', serviceName, m.name)
+    r[_.camelCase(m.name)].fullName = getFullName(packageName, serviceName, m.name)
   })
 
   return r

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -15,12 +15,47 @@ function actionMapper (action, name) {
   return r
 }
 
-exports.getMethodDescriptors = function (service) {
+function getFullName (packageName, serviceName, name) {
+  return '/'.concat(packageName, '.', serviceName, '/', name)
+}
+
+function getPackageName (path) {
+  if (path && path.indexOf('/') === 0) {
+    return path.substring(1, path.indexOf('.'))
+  }
+  return ''
+}
+
+exports.getMethodDescriptorsProto = function (serviceName, service) {
   const r = {}
+  let packageName = ''
   _.forOwn(service, (action, name) => {
     if (action && _.isString(action.path)) {
+      if (!packageName) {
+        packageName = getPackageName(action.path)
+      }
+
       r[name] = actionMapper(action, name)
+      r[name].service = serviceName
+      if (packageName) {
+        r[name].package = packageName
+        r[name].fullName = getFullName(packageName, serviceName, name)
+      }
     }
   })
+  return r
+}
+
+exports.getMethodDescriptorsLoad = function (serviceName, service, descriptor) {
+  const r = {}
+  const methods = descriptor.methods(serviceName)
+  const packageName = service.parent.name
+  methods.forEach(m => {
+    r[_.camelCase(m.name)] = m
+    r[_.camelCase(m.name)].package = packageName
+    r[_.camelCase(m.name)].service = serviceName
+    r[_.camelCase(m.name)].fullName = getFullName('', serviceName, m.name)
+  })
+
   return r
 }

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -77,13 +77,15 @@ test.cb('should not affect the original prototype', t => {
 })
 
 test.cb('should have correct properties for req / res', t => {
-  t.plan(18)
+  t.plan(20)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
 
   function sayHello (ctx) {
     t.truthy(ctx)
     t.truthy(ctx.req)
+    t.truthy(ctx.metadata)
+    t.truthy(ctx.app)
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
@@ -115,7 +117,7 @@ test.cb('should have correct properties for req / res', t => {
 })
 
 test.cb('should have correct properties for req / res with proto', t => {
-  t.plan(18)
+  t.plan(20)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
 
@@ -124,6 +126,8 @@ test.cb('should have correct properties for req / res with proto', t => {
   function sayHello (ctx) {
     t.truthy(ctx)
     t.truthy(ctx.req)
+    t.truthy(ctx.metadata)
+    t.truthy(ctx.app)
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
@@ -158,13 +162,15 @@ test.cb('should have correct properties for req / res with proto', t => {
 })
 
 test.cb('should have correct properties res stream request', t => {
-  t.plan(16)
+  t.plan(18)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/resstream.proto')
 
   function listStuff (ctx) {
     t.truthy(ctx)
     t.truthy(ctx.req)
+    t.truthy(ctx.metadata)
+    t.truthy(ctx.app)
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
@@ -212,13 +218,15 @@ test.cb('should have correct properties res stream request', t => {
 })
 
 test.cb('should have correct properties for req stream', t => {
-  t.plan(19)
+  t.plan(21)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/reqstream.proto')
 
   async function writeStuff (ctx) {
     t.truthy(ctx)
     t.truthy(ctx.req)
+    t.truthy(ctx.metadata)
+    t.truthy(ctx.app)
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
@@ -275,13 +283,15 @@ test.cb('should have correct properties for req stream', t => {
 })
 
 test.cb('should have correct properties for duplex call', t => {
-  t.plan(17)
+  t.plan(19)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/duplex.proto')
 
   async function processStuff (ctx) {
     t.truthy(ctx)
     t.truthy(ctx.req)
+    t.truthy(ctx.metadata)
+    t.truthy(ctx.app)
     t.truthy(ctx.res)
     t.truthy(ctx.call)
     t.truthy(ctx.type)

--- a/test/context.test.js
+++ b/test/context.test.js
@@ -77,7 +77,7 @@ test.cb('should not affect the original prototype', t => {
 })
 
 test.cb('should have correct properties for req / res', t => {
-  t.plan(12)
+  t.plan(18)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
 
@@ -87,7 +87,13 @@ test.cb('should have correct properties for req / res', t => {
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
+    t.truthy(ctx.fullName)
+    t.truthy(ctx.service)
+    t.truthy(ctx.package)
     t.is(ctx.name, 'SayHello')
+    t.is(ctx.fullName, '/helloworld.Greeter/SayHello')
+    t.is(ctx.service, 'Greeter')
+    t.is(ctx.package, 'helloworld')
     t.is(ctx.type, CallType.UNARY)
     ctx.res = { message: 'Hello ' + ctx.req.name }
   }
@@ -108,8 +114,51 @@ test.cb('should have correct properties for req / res', t => {
   })
 })
 
+test.cb('should have correct properties for req / res with proto', t => {
+  t.plan(18)
+  const APP_HOST = tu.getHost()
+  const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
+
+  const messages = require('./static/helloworld_pb')
+
+  function sayHello (ctx) {
+    t.truthy(ctx)
+    t.truthy(ctx.req)
+    t.truthy(ctx.call)
+    t.truthy(ctx.type)
+    t.truthy(ctx.name)
+    t.truthy(ctx.fullName)
+    t.truthy(ctx.service)
+    t.truthy(ctx.package)
+    t.is(ctx.name, 'sayHello')
+    t.is(ctx.fullName, '/helloworld.GreeterService/sayHello')
+    t.is(ctx.service, 'GreeterService')
+    t.is(ctx.package, 'helloworld')
+    t.is(ctx.type, CallType.UNARY)
+    const reply = new messages.HelloReply()
+    reply.setMessage('Hello ' + ctx.req.getName())
+    ctx.res = reply
+  }
+
+  const services = require('./static/helloworld_grpc_pb')
+  const app = new Mali(services)
+  t.truthy(app)
+  app.use({ sayHello })
+  const server = app.start(APP_HOST)
+  t.truthy(server)
+
+  const helloproto = grpc.load(PROTO_PATH).helloworld
+  const client = new helloproto.Greeter(APP_HOST, grpc.credentials.createInsecure())
+  client.sayHello({ name: 'Bob' }, (err, response) => {
+    t.ifError(err)
+    t.truthy(response)
+    t.is(response.message, 'Hello Bob')
+    app.close().then(() => t.end())
+  })
+})
+
 test.cb('should have correct properties res stream request', t => {
-  t.plan(10)
+  t.plan(16)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/resstream.proto')
 
@@ -119,7 +168,13 @@ test.cb('should have correct properties res stream request', t => {
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
+    t.truthy(ctx.fullName)
+    t.truthy(ctx.service)
+    t.truthy(ctx.package)
     t.is(ctx.name, 'ListStuff')
+    t.is(ctx.fullName, '/argservice.ArgService/ListStuff')
+    t.is(ctx.service, 'ArgService')
+    t.is(ctx.package, 'argservice')
     t.is(ctx.type, CallType.RESPONSE_STREAM)
 
     ctx.res = hl(_.cloneDeep(ARRAY_DATA))
@@ -157,7 +212,7 @@ test.cb('should have correct properties res stream request', t => {
 })
 
 test.cb('should have correct properties for req stream', t => {
-  t.plan(13)
+  t.plan(19)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/reqstream.proto')
 
@@ -167,7 +222,13 @@ test.cb('should have correct properties for req stream', t => {
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
+    t.truthy(ctx.fullName)
+    t.truthy(ctx.service)
+    t.truthy(ctx.package)
     t.is(ctx.name, 'WriteStuff')
+    t.is(ctx.fullName, '/argservice.ArgService/WriteStuff')
+    t.is(ctx.service, 'ArgService')
+    t.is(ctx.package, 'argservice')
     t.is(ctx.type, CallType.REQUEST_STREAM)
 
     return new Promise((resolve, reject) => {
@@ -214,7 +275,7 @@ test.cb('should have correct properties for req stream', t => {
 })
 
 test.cb('should have correct properties for duplex call', t => {
-  t.plan(11)
+  t.plan(17)
   const APP_HOST = tu.getHost()
   const PROTO_PATH = path.resolve(__dirname, './protos/duplex.proto')
 
@@ -225,7 +286,13 @@ test.cb('should have correct properties for duplex call', t => {
     t.truthy(ctx.call)
     t.truthy(ctx.type)
     t.truthy(ctx.name)
+    t.truthy(ctx.fullName)
+    t.truthy(ctx.service)
+    t.truthy(ctx.package)
     t.is(ctx.name, 'ProcessStuff')
+    t.is(ctx.fullName, '/argservice.ArgService/ProcessStuff')
+    t.is(ctx.service, 'ArgService')
+    t.is(ctx.package, 'argservice')
     t.is(ctx.type, CallType.DUPLEX)
 
     ctx.req.on('data', d => {


### PR DESCRIPTION
* Added the following to properties to `context`:
- `{String} fullName` - the full name of the call. ie `'/helloworld.Greeter/SayHello'`
- `{String} service` - the service name of the call. ie `'Greeter`
- `{String} package` - the package name of the call. ie `'helloworld`
* Various minor improvements