### PR TITLE
Res stream error

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -71,6 +71,10 @@ function execRes (ctx, fn) {
 function execStream (ctx, fn) {
   fn(ctx.ctx).then(() => {
     ctx.ctx.res.pipe(ctx.call)
+    ctx.ctx.res.once('error', err => {
+      ctx.call.emit('error', err)
+      onerror(err, ctx)
+    })
   }).catch(err => {
     ctx.call.emit('error', err)
     onerror(err, ctx)


### PR DESCRIPTION
I had a problem where a error emitted through the stream pipeline did not propagate to a client. Instead it leaked through and killed the process. The test demonstrates the scenario and the change in `run.js` seems to fix it.