### PR TITLE
Add protobuf.js 6 support. Addresses #10.

### DIFF
--- a/API.md
+++ b/API.md
@@ -1,35 +1,35 @@
 ### Classes
 
 <dl>
-<dt>[Context](#contextclass)</dt>
+<dt><a href="#Context">Context</a></dt>
 <dd><p>Represents a RPC call context.</p>
 </dd>
-<dt>[Mali](#maliclass) ⇐ <code>Emitter</code></dt>
+<dt><a href="#Mali">Mali</a> ⇐ <code>Emitter</code></dt>
 <dd><p>Represents a gRPC service</p>
 </dd>
 </dl>
 
-<a name="contextclass" id="contextclass" data-id="contextclass"></a>
+<a name="context" id="context" data-id="context"></a>
 
 ### Context
 Represents a RPC call context.
 
 **Kind**: global class  
 
-* [Context](#contextclass)
-    * [new Context()](#newcontextnew)
-    * [.name](#contextname) : <code>String</code>
-    * [.fullName](#contextfullName) : <code>String</code>
-    * [.service](#contextservice) : <code>String</code>
-    * [.package](#contextpackage) : <code>String</code>
-    * [.type](#contexttype) : <code>String</code>
-    * [.req](#contextreq) : <code>Object</code>, <code>Stream</code>
-    * [.res](#contextres) : <code>Object</code>, <code>Stream</code>
-    * [.metadata](#contextmetadata) : <code>Object</code>
-    * [.app](#contextapp) : <code>Object</code>
-    * [.call](#contextcall) : <code>Object</code>
+* [Context](#Context)
+    * [new Context()](#new_Context_new)
+    * [.name](#Contextname) : <code>String</code>
+    * [.fullName](#ContextfullName) : <code>String</code>
+    * [.service](#Contextservice) : <code>String</code>
+    * [.package](#Contextpackage) : <code>String</code>
+    * [.type](#Contexttype) : <code>String</code>
+    * [.req](#Contextreq) : <code>Object</code> \| <code>Stream</code>
+    * [.res](#Contextres) : <code>Object</code> \| <code>Stream</code>
+    * [.metadata](#Contextmetadata) : <code>Object</code>
+    * [.app](#Contextapp) : <code>Object</code>
+    * [.call](#Contextcall) : <code>Object</code>
 
-<a name="newcontextnew" id="newcontextnew" data-id="newcontextnew"></a>
+<a name="new_context_new" id="new_context_new" data-id="new_context_new"></a>
 
 #### new Context()
 Context constructor. Clients do not need to call this.
@@ -48,7 +48,7 @@ async function toUpper(ctx) {
 #### context.name : <code>String</code>
 The call function name.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -60,7 +60,7 @@ console.log(ctx.name) // 'SayHello'
 #### context.fullName : <code>String</code>
 The full name of the call.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -72,7 +72,7 @@ console.log(ctx.fullName) // '/helloworld.Greeter/SayHello'
 #### context.service : <code>String</code>
 The service name of the call.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -84,7 +84,7 @@ console.log(ctx.service) // 'Greeter'
 #### context.package : <code>String</code>
 The package name of the call.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -96,7 +96,7 @@ console.log(ctx.package) // 'helloworld'
 #### context.type : <code>String</code>
 The call type. One of <code>CallType</code> enums.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -113,10 +113,10 @@ if(ctx.type === CallType.DUPLEX) {
 
 <a name="contextreq" id="contextreq" data-id="contextreq"></a>
 
-#### context.req : <code>Object</code>, <code>Stream</code>
+#### context.req : <code>Object</code> \| <code>Stream</code>
 The request object or stream.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -125,10 +125,10 @@ console.dir(ctx.req) // { name: 'Bob' }
 
 <a name="contextres" id="contextres" data-id="contextres"></a>
 
-#### context.res : <code>Object</code>, <code>Stream</code>
+#### context.res : <code>Object</code> \| <code>Stream</code>
 The response object or stream. Should be set in handler.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -140,7 +140,7 @@ ctx.res = { name: 'Bob' }
 #### context.metadata : <code>Object</code>
 The call metadata if present.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 **Example**  
 
 ```js
@@ -153,14 +153,14 @@ console.log(ctx.metadata)
 #### context.app : <code>Object</code>
 The application instance reference.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
+**Kind**: instance property of [<code>Context</code>](#Context)  
 <a name="contextcall" id="contextcall" data-id="contextcall"></a>
 
 #### context.call : <code>Object</code>
 The internal gRPC call instance reference.
 
-**Kind**: instance property of <code>[Context](#context)</code>  
-<a name="Maliclass" id="Maliclass" data-id="Maliclass"></a>
+**Kind**: instance property of [<code>Context</code>](#Context)  
+<a name="mali" id="mali" data-id="mali"></a>
 
 ### Mali ⇐ <code>Emitter</code>
 Represents a gRPC service
@@ -168,18 +168,18 @@ Represents a gRPC service
 **Kind**: global class  
 **Extends**: <code>Emitter</code>  
 
-* [Mali](#mali) ⇐ <code>Emitter</code>
+* [Mali](#Mali) ⇐ <code>Emitter</code>
     * [new Mali(proto, name, options)](#new_Mali_new)
-    * [.name](#maliname) : <code>String</code>
-    * [.env](#malienv) : <code>String</code>
-    * [.silent](#malisilent) : <code>Boolean</code>
-    * [.init(proto, name, options)](#maliinit)
-    * [.use(service, name, ...fns)](#maliuse)
-    * [.onerror(err)](#malionerror)
-    * [.start(port, creds)](#malistart) ⇒ <code>Object</code>
-    * [.close()](#maliclose)
-    * [.toJSON()](#malitoJSON) ⇒ <code>Object</code>
-    * [.inspect()](#maliinspect) ⇒ <code>Object</code>
+    * [.name](#Maliname) : <code>String</code>
+    * [.env](#Malienv) : <code>String</code>
+    * [.silent](#Malisilent) : <code>Boolean</code>
+    * [.init(proto, name, options)](#Maliinit)
+    * [.use(service, name, ...fns)](#Maliuse)
+    * [.onerror(err)](#Malionerror)
+    * [.start(port, creds)](#Malistart) ⇒ <code>Object</code>
+    * [.close()](#Maliclose)
+    * [.toJSON()](#MalitoJSON) ⇒ <code>Object</code>
+    * [.inspect()](#Maliinspect) ⇒ <code>Object</code>
 
 <a name="new_mali_new" id="new_mali_new" data-id="new_mali_new"></a>
 
@@ -189,7 +189,7 @@ Create a gRPC service
 
 | Param | Type | Description |
 | --- | --- | --- |
-| proto | <code>String</code>, <code>Object</code> | Path to the protocol buffer definition file                              - Object specifying <code>root</code> directory and <code>file</code> to load                              - The static service proto object itself |
+| proto | <code>String</code> \| <code>Object</code> | Path to the protocol buffer definition file                              - Object specifying <code>root</code> directory and <code>file</code> to load                              - Loaded grpc object                              - The static service proto object itself |
 | name | <code>Object</code> | Optional name of the service or an array of names. Otherwise all services are used.                      In case of proto path the name of the service as defined in the proto definition.                      In case of proto object the name of the constructor. |
 | options | <code>Object</code> | Options to be passed to <code>grpc.load</code> |
 
@@ -212,7 +212,7 @@ const app = new Mali(services, 'GreeterService')
 #### mali.name : <code>String</code>
 The service name
 
-**Kind**: instance property of <code>[Mali](#mali)</code>  
+**Kind**: instance property of [<code>Mali</code>](#Mali)  
 **Example**  
 
 ```js
@@ -224,7 +224,7 @@ console.log(app.name) // 'Greeter'
 #### mali.env : <code>String</code>
 The environment. Taken from <code>process.end.NODE_ENV</code>. Default: <code>development</code>
 
-**Kind**: instance property of <code>[Mali](#mali)</code>  
+**Kind**: instance property of [<code>Mali</code>](#Mali)  
 **Example**  
 
 ```js
@@ -236,18 +236,18 @@ console.log(app.env) // 'development'
 #### mali.silent : <code>Boolean</code>
 Whether to log errors in <code>onerror</code>. Default: <code>false</code>
 
-**Kind**: instance property of <code>[Mali](#mali)</code>  
+**Kind**: instance property of [<code>Mali</code>](#Mali)  
 <a name="maliinit" id="maliinit" data-id="maliinit"></a>
 
 #### mali.init(proto, name, options)
 Init's the app with the proto. Basically this can be used if you don't have the data at
 app construction time for some reason.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| proto | <code>String</code>, <code>Object</code> | Path to the protocol buffer definition file                              - Object specifying <code>root</code> directory and <code>file</code> to load                              - The static service proto object itself |
+| proto | <code>String</code> \| <code>Object</code> | Path to the protocol buffer definition file                              - Object specifying <code>root</code> directory and <code>file</code> to load                              - Loaded grpc object                              - The static service proto object itself |
 | name | <code>Object</code> | Optional name of the service or an array of names. Otherwise all services are used.                      In case of proto path the name of the service as defined in the proto definition.                      In case of proto object the name of the constructor. |
 | options | <code>Object</code> | Options to be passed to <code>grpc.load</code> |
 
@@ -267,13 +267,13 @@ If an <code>object</code> is provided, you can set middleware and handlers for a
 If <code>object</code> provided but <code>0</code>th key does not match any of the services in
 proto, assumes <code>0</code>th service. Useful for protos with only one service.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 
 | Param | Type | Description |
 | --- | --- | --- |
-| service | <code>String</code>, <code>Object</code> | Service name |
-| name | <code>String</code>, <code>function</code> | RPC name |
-| ...fns | <code>function</code>, <code>Array</code> | Middleware and/or handler |
+| service | <code>String</code> \| <code>Object</code> | Service name |
+| name | <code>String</code> \| <code>function</code> | RPC name |
+| ...fns | <code>function</code> \| <code>Array</code> | Middleware and/or handler |
 
 **Example** *(Define handler for rpc function &#x27;fn1&#x27;)*  
 
@@ -333,7 +333,7 @@ app.use({
 #### mali.onerror(err)
 Default error handler.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 
 | Param | Type |
 | --- | --- |
@@ -344,7 +344,7 @@ Default error handler.
 #### mali.start(port, creds) ⇒ <code>Object</code>
 Start the service. All middleware and handlers have to be set up prior to calling <code>start</code>.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 **Returns**: <code>Object</code> - server - The <code>grpc.Server</code> instance  
 
 | Param | Type | Default | Description |
@@ -363,7 +363,7 @@ app.start('localhost:50051')
 #### mali.close()
 Close the service(s).
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 **Example**  
 
 ```js
@@ -376,11 +376,11 @@ app.close()
 Return JSON representation.
 We only bother showing settings.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  
 **Api**: public  
 <a name="maliinspect" id="maliinspect" data-id="maliinspect"></a>
 
 #### mali.inspect() ⇒ <code>Object</code>
 Inspect implementation.
 
-**Kind**: instance method of <code>[Mali](#mali)</code>  
+**Kind**: instance method of [<code>Mali</code>](#Mali)  

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ class Mali extends Emitter {
    * @class
    * @param {String|Object} proto - Path to the protocol buffer definition file
    *                              - Object specifying <code>root</code> directory and <code>file</code> to load
+   *                              - Loaded grpc object
    *                              - The static service proto object itself
    * @param {Object} name - Optional name of the service or an array of names. Otherwise all services are used.
    *                      In case of proto path the name of the service as defined in the proto definition.
@@ -59,6 +60,7 @@ class Mali extends Emitter {
    * app construction time for some reason.
    * @param {String|Object} proto - Path to the protocol buffer definition file
    *                              - Object specifying <code>root</code> directory and <code>file</code> to load
+   *                              - Loaded grpc object
    *                              - The static service proto object itself
    * @param {Object} name - Optional name of the service or an array of names. Otherwise all services are used.
    *                      In case of proto path the name of the service as defined in the proto definition.

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,7 @@ class Mali extends Emitter {
 
     this.services = {}
     this.methods = {}
-    if (this.load) {
+    if (this.load || mu.isProbablyProtobufJs5(this.proto) || mu.isProbablyProtobufJs6(this.proto)) {
       let descriptor = gi(this.proto)
       if (!descriptor) {
         throw new Error(String.raw`Error parsing protocol buffer`)
@@ -262,8 +262,6 @@ class Mali extends Emitter {
       creds = this.grpc.ServerCredentials.createInsecure()
     }
 
-    const method = this.load ? 'addProtoService' : 'addService'
-
     _.forOwn(this.services, (s, sn) => {
       const composed = {}
       const methods = this.methods[sn]
@@ -272,7 +270,7 @@ class Mali extends Emitter {
         _.forOwn(handlers, (v, k) => {
           composed[k] = this.callback(methods[k], v)
         })
-        server[method](s, composed)
+        server.addService(s, composed)
       }
     })
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -72,7 +72,7 @@ class Mali extends Emitter {
 
     this.services = {}
     this.methods = {}
-    if (this.load || mu.isProbablyProtobufJs5(this.proto) || mu.isProbablyProtobufJs6(this.proto)) {
+    if (this.load || !mu.isStaticGRPCObject(this.proto)) {
       let descriptor = gi(this.proto)
       if (!descriptor) {
         throw new Error(String.raw`Error parsing protocol buffer`)
@@ -85,7 +85,7 @@ class Mali extends Emitter {
       }
       names.forEach(n => {
         const client = descriptor.client(n)
-        const service = client ? client.service : null
+        const service = client && client.service ? client.service : client
         if (service) {
           this.services[n] = service
           this.middleware[n] = []

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,10 +49,14 @@ exports.getMethodDescriptorsProto = function (serviceName, service) {
 exports.getMethodDescriptorsLoad = function (serviceName, service, descriptor) {
   const r = {}
   const methods = descriptor.methods(serviceName)
+  const serviceDescriptor = descriptor.service(serviceName)
   let packageName = ''
   if (service && service.parent && service.parent.name) {
     packageName = service.parent.name
+  } else if (serviceDescriptor && serviceDescriptor.package) {
+    packageName = serviceDescriptor.package
   }
+
   methods.forEach(m => {
     r[_.camelCase(m.name)] = m
     r[_.camelCase(m.name)].name = _.upperFirst(m.name)
@@ -63,3 +67,11 @@ exports.getMethodDescriptorsLoad = function (serviceName, service, descriptor) {
 
   return r
 }
+
+exports.isProbablyProtobufJs6 = function isProbablyProtobufJs6 (obj) {
+  return (typeof obj.root === 'object') && (typeof obj.resolve === 'function')
+}
+
+exports.isProbablyProtobufJs5 = function isProbablyProtobufJs5 (obj) {
+  return _.isArray(obj.children) && (typeof obj.build === 'function')
+};

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -68,10 +68,20 @@ exports.getMethodDescriptorsLoad = function (serviceName, service, descriptor) {
   return r
 }
 
-exports.isProbablyProtobufJs6 = function isProbablyProtobufJs6 (obj) {
-  return (typeof obj.root === 'object') && (typeof obj.resolve === 'function')
-}
+exports.isStaticGRPCObject = function (proto) {
+  if (!proto) {
+    return false
+  }
 
-exports.isProbablyProtobufJs5 = function isProbablyProtobufJs5 (obj) {
-  return _.isArray(obj.children) && (typeof obj.build === 'function')
-};
+  const vs = _.values(proto)
+
+  if (!vs || !vs.length) {
+    return false
+  }
+
+  const t = _.find(vs, v => {
+    return v && _.isFunction(v) && v.service
+  })
+
+  return Boolean(t)
+}

--- a/package.json
+++ b/package.json
@@ -34,8 +34,8 @@
     "destroy": "^1.0.4",
     "ee-first": "^1.1.1",
     "error-inject": "^1.0.0",
-    "grpc": "^1.2.0",
-    "grpc-inspect": "^0.2.0",
+    "grpc": "^1.3.0",
+    "grpc-inspect": "bojand/grpc-inspect#grpc13",
     "is-stream": "^1.1.0",
     "lodash": "^4.17.0",
     "mali-call-types": "~0.1.0",
@@ -44,13 +44,14 @@
     "pify": "^2.3.0"
   },
   "devDependencies": {
-    "ava": "^0.18.1",
+    "ava": "^0.19.1",
     "babel-eslint": "^7.1.1",
     "google-protobuf": "^3.1.1",
     "highland": "^3.0.0-beta.3",
     "jsdoc-to-markdown": "^3.0.0",
     "md-wrap-code": "^0.1.1",
-    "standard": "^9.0.0",
+    "protobufjs": "^6.7.3",
+    "standard": "^10.0.0",
     "test-console": "^1.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -50,8 +50,7 @@
     "highland": "^3.0.0-beta.3",
     "jsdoc-to-markdown": "^3.0.0",
     "md-wrap-code": "^0.1.1",
-    "protobufjs": "^6.7.3",
-    "standard": "^10.0.0",
+    "protobufjs6": "./test/protobufjs6",
     "test-console": "^1.0.0"
   },
   "directories": {

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     "ee-first": "^1.1.1",
     "error-inject": "^1.0.0",
     "grpc": "^1.3.0",
-    "grpc-inspect": "bojand/grpc-inspect#grpc13",
+    "grpc-inspect": "~0.3.0",
     "is-stream": "^1.1.0",
     "lodash": "^4.17.0",
     "mali-call-types": "~0.1.0",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -4,7 +4,7 @@ import grpc from 'grpc'
 import hl from 'highland'
 import async from 'async'
 import _ from 'lodash'
-import protobuf from 'protobufjs'
+import protobuf from 'protobufjs6'
 
 import Mali from '../lib'
 import * as tu from './util'

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -4,6 +4,7 @@ import grpc from 'grpc'
 import hl from 'highland'
 import async from 'async'
 import _ from 'lodash'
+import protobuf from 'protobufjs'
 
 import Mali from '../lib'
 import * as tu from './util'
@@ -67,6 +68,38 @@ test.cb('should handle req/res request', t => {
     t.truthy(response)
     t.is(response.message, 'Hello Bob')
     app.close().then(() => t.end())
+  })
+})
+
+test.cb('should handle req/res request with protobufjs 6', t => {
+  t.plan(8)
+  const APP_HOST = tu.getHost()
+  const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
+
+  function sayHello (ctx) {
+    ctx.res = { message: 'Hello ' + ctx.req.name }
+  }
+
+  protobuf.load(PROTO_PATH, (err, root) => {
+    t.ifError(err)
+    t.truthy(root)
+    const loaded = grpc.loadObject(root)
+    t.truthy(loaded)
+
+    const app = new Mali(loaded)
+    t.truthy(app)
+    app.use({ sayHello })
+    const server = app.start(APP_HOST)
+    t.truthy(server)
+
+    const helloproto = grpc.load(PROTO_PATH).helloworld
+    const client = new helloproto.Greeter(APP_HOST, grpc.credentials.createInsecure())
+    client.sayHello({ name: 'Bob' }, (err, response) => {
+      t.ifError(err)
+      t.truthy(response)
+      t.is(response.message, 'Hello Bob')
+      app.close().then(() => t.end())
+    })
   })
 })
 

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -3,7 +3,7 @@ import grpc from 'grpc'
 import path from 'path'
 import _ from 'lodash'
 import pMap from 'p-map'
-import protobuf from 'protobufjs'
+import protobuf from 'protobufjs6'
 
 import Mali from '../lib'
 import * as tu from './util'

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -1,4 +1,5 @@
 import test from 'ava'
+import grpc from 'grpc'
 import path from 'path'
 import _ from 'lodash'
 import pMap from 'p-map'
@@ -59,8 +60,8 @@ test.serial('should statically create service', t => {
   t.truthy(server)
 })
 
-test.serial.only('should work with protobuf 6 loaded object', async t => {
-  t.plan(3)
+test.serial('should work with protobuf 6 loaded object', async t => {
+  t.plan(4)
   const root = await protobuf.load(PROTO_PATH)
   t.truthy(root)
 
@@ -68,7 +69,9 @@ test.serial.only('should work with protobuf 6 loaded object', async t => {
     ctx.res = { message: 'Hello ' + ctx.req.name }
   }
 
-  const app = new Mali(PROTO_PATH)
+  const loaded = grpc.loadObject(root)
+  t.truthy(loaded)
+  const app = new Mali(loaded)
   t.truthy(app)
   apps.push(app)
 

--- a/test/create.test.js
+++ b/test/create.test.js
@@ -2,6 +2,7 @@ import test from 'ava'
 import path from 'path'
 import _ from 'lodash'
 import pMap from 'p-map'
+import protobuf from 'protobufjs'
 
 import Mali from '../lib'
 import * as tu from './util'
@@ -58,6 +59,24 @@ test.serial('should statically create service', t => {
   t.truthy(server)
 })
 
+test.serial.only('should work with protobuf 6 loaded object', async t => {
+  t.plan(3)
+  const root = await protobuf.load(PROTO_PATH)
+  t.truthy(root)
+
+  function sayHello (ctx) {
+    ctx.res = { message: 'Hello ' + ctx.req.name }
+  }
+
+  const app = new Mali(PROTO_PATH)
+  t.truthy(app)
+  apps.push(app)
+
+  app.use({ sayHello })
+  const server = app.start(tu.getHost())
+  t.truthy(server)
+})
+
 test.serial('should statically create service without a service name', t => {
   const messages = require('./static/helloworld_pb')
   const services = require('./static/helloworld_grpc_pb')
@@ -78,6 +97,8 @@ test.serial('should statically create service without a service name', t => {
 })
 
 test.serial('should dynamically create service using object specifying root and file', async t => {
+  t.plan(2)
+
   function sayHello (ctx) {
     ctx.res = { message: 'Hello ' + ctx.req.name }
   }
@@ -98,6 +119,8 @@ test.serial('should dynamically create service using object specifying root and 
 })
 
 test.serial('should dynamically create service using object specifying root and file using imports', async t => {
+  t.plan(2)
+
   function sayHello (ctx) {
     ctx.res = { message: 'Hello ' + ctx.req.name }
   }

--- a/test/protobufjs6/index.js
+++ b/test/protobufjs6/index.js
@@ -1,0 +1,1 @@
+module.exports = require('protobufjs')

--- a/test/protobufjs6/package.json
+++ b/test/protobufjs6/package.json
@@ -1,0 +1,4 @@
+{ "name": "protobufjs6",
+  "version": "1.0.0",
+  "description":"protobufjs 6",
+  "dependencies": { "protobufjs":"^6.7.0" } }


### PR DESCRIPTION
Sample usage

```js
const grpc = require('grpc') // latest grpc
const pb = require('protobufjs') // protobuf 6
const Mali = require('mali')

function sayHello (ctx) {
  ctx.res = { message: 'Hello ' + ctx.req.name }
}

async function main() {
  const proto = await pb.load('./protos/helloworld.proto')
  const loaded = grpc.loadObject(proto)
  const app = new Mali(loaded)
  app.use({ sayHello })
  const server = app.start('0.0.0.0:50051')
}

main()
```
