### PR TITLE
fix: use exact version 0.3.2 of grpc-inspect

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4485,9 +4485,9 @@
       }
     },
     "grpc-inspect": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/grpc-inspect/-/grpc-inspect-0.3.3.tgz",
-      "integrity": "sha512-SLZHpAdVugBBh5h5Kelh3r5XO4zA2qXWA5u54xuX5zLjW2jY9Xaj99F3enyUYYy/2UpmQTf2Ywy4PdU0h2CumQ==",
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/grpc-inspect/-/grpc-inspect-0.3.2.tgz",
+      "integrity": "sha512-/lpXgIGbhxVOggEO5+57oFE0J6cfXQa9Fdqcdh8myinuZx2ldpjS6ZKssGvZKT2KXNFms7Lq6YEGNFLFJcgWzA==",
       "requires": {
         "lodash": "4.17.4"
       }

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
     "error-inject": "^1.0.0",
     "grpc": "^1.7.1",
     "grpc-create-metadata": "^2.0.0",
-    "grpc-inspect": "~0.3.3",
+    "grpc-inspect": "0.3.2",
     "is-stream": "^1.1.0",
     "lodash": "^4.17.0",
     "lodash.camelcase": "^4.3.0",


### PR DESCRIPTION
grpc-inspect 0.3.3 can not process proto files with import. This in turn made it impossible to use mali with proto files that has import. This PR attempts to use grpc-inspect 0.3.2 which works well with proto import. The issue was raised [here](https://github.com/bojand/grpc-inspect/issues/8)