### PR TITLE
Dynamic OS-assigned ports.

### DIFF
--- a/API.md
+++ b/API.md
@@ -30,6 +30,7 @@ Represents a gRPC service
     * [.silent](#Malisilent) : <code>Boolean</code>
     * [.name](#Maliname) : <code>String</code>
     * [.env](#Malienv) : <code>String</code>
+    * [.ports](#Maliports) : <code>Array</code>
     * [.init(proto, name, options)](#Maliinit)
     * [.use(service, name, ...fns)](#Maliuse)
     * [.onerror(err)](#Malionerror)
@@ -92,6 +93,18 @@ The environment. Taken from <code>process.end.NODE_ENV</code>. Default: <code>de
 
 ```js
 console.log(app.env) // 'development'
+```
+
+<a name="maliports" id="maliports" data-id="maliports"></a>
+
+#### mali.ports : <code>Array</code>
+The ports of the started service(s)
+
+**Kind**: instance property of [<code>Mali</code>](#Mali)  
+**Example**  
+
+```js
+console.log(app.ports) // [ 52239 ]
 ```
 
 <a name="maliinit" id="maliinit" data-id="maliinit"></a>
@@ -204,15 +217,22 @@ Start the service. All middleware and handlers have to be set up prior to callin
 **Kind**: instance method of [<code>Mali</code>](#Mali)  
 **Returns**: <code>Object</code> - server - The <code>grpc.Server</code> instance  
 
-| Param | Type | Default | Description |
-| --- | --- | --- | --- |
-| port | <code>String</code> |  | The hostport for the service |
-| creds | <code>Object</code> | <code></code> | Credentials options. Default: <code>grpc.ServerCredentials.createInsecure()</code> |
+| Param | Type | Description |
+| --- | --- | --- |
+| port | <code>String</code> | The hostport for the service |
+| creds | <code>Object</code> | Credentials options. Default: <code>grpc.ServerCredentials.createInsecure()</code> |
 
 **Example**  
 
 ```js
 app.start('localhost:50051')
+```
+
+**Example** *(Start same app on multiple ports)*  
+
+```js
+app.start('0.0.0.0:50050')
+app.start('0.0.0.0:50051')
 ```
 
 <a name="maliclose" id="maliclose" data-id="maliclose"></a>

--- a/API.md
+++ b/API.md
@@ -219,7 +219,7 @@ Start the service. All middleware and handlers have to be set up prior to callin
 
 | Param | Type | Description |
 | --- | --- | --- |
-| port | <code>String</code> | The hostport for the service |
+| port | <code>String</code> | The hostport for the service. Default: <code>127.0.0.1:0</code> |
 | creds | <code>Object</code> | Credentials options. Default: <code>grpc.ServerCredentials.createInsecure()</code> |
 
 **Example**  
@@ -231,8 +231,8 @@ app.start('localhost:50051')
 **Example** *(Start same app on multiple ports)*  
 
 ```js
-app.start('0.0.0.0:50050')
-app.start('0.0.0.0:50051')
+app.start('127.0.0.1:50050')
+app.start('127.0.0.1:50051')
 ```
 
 <a name="maliclose" id="maliclose" data-id="maliclose"></a>

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ async function sayHello (ctx) {
 function main () {
   const app = new Mali(PROTO_PATH)
   app.use({ sayHello })
-  app.start('0.0.0.0:50051')
+  app.start('127.0.0.1:50051')
 }
 ```
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -266,7 +266,7 @@ class Mali extends Emitter {
       port = null
     }
 
-    if (!_.isString(port) || (_.isString(port) && port.length === 0)) {
+    if (!port || !_.isString(port) || (_.isString(port) && port.length === 0)) {
       port = '127.0.0.1:0'
     }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -251,14 +251,14 @@ class Mali extends Emitter {
 
   /**
    * Start the service. All middleware and handlers have to be set up prior to calling <code>start</code>.
-   * @param {String} port - The hostport for the service
+   * @param {String} port - The hostport for the service. Default: <code>127.0.0.1:0</code>
    * @param {Object} creds - Credentials options. Default: <code>grpc.ServerCredentials.createInsecure()</code>
    * @return {Object} server - The <code>grpc.Server</code> instance
    * @example
    * app.start('localhost:50051')
    * @example <caption>Start same app on multiple ports</caption>
-   * app.start('0.0.0.0:50050')
-   * app.start('0.0.0.0:50051')
+   * app.start('127.0.0.1:50050')
+   * app.start('127.0.0.1:50051')
    */
   start (port, creds) {
     if (_.isObject(port) && !creds) {
@@ -267,7 +267,7 @@ class Mali extends Emitter {
     }
 
     if (!_.isString(port) || (_.isString(port) && port.length === 0)) {
-      port = '0.0.0.0:0'
+      port = '127.0.0.1:0'
     }
 
     const server = new this.grpc.Server()

--- a/lib/app.js
+++ b/lib/app.js
@@ -47,6 +47,7 @@ class Mali extends Emitter {
     this.middleware = {} // just the global middleware
     this.handlers = {} // specific middleware and handlers
     this.servers = []
+    this.ports = []
 
     // app options / settings
     this.context = new Context()
@@ -257,6 +258,15 @@ class Mali extends Emitter {
    * app.start('localhost:50051')
    */
   start (port, creds = null) {
+    if (_.isObject(port) && !creds) {
+      creds = port
+      port = null
+    }
+
+    if (!_.isString(port) || (_.isString(port) && port.length === 0)) {
+      port = '0.0.0.0:0'
+    }
+
     const server = new this.grpc.Server()
     server.tryShutdownAsync = pify(server.tryShutdown)
     if (!creds) {
@@ -275,10 +285,13 @@ class Mali extends Emitter {
       }
     })
 
-    server.bind(port, creds)
+    this.ports.push(server.bind(port, creds))
 
     server.start()
-    this.servers.push(server)
+    this.servers.push({
+      server,
+      port
+    })
     return server
   }
 
@@ -288,7 +301,7 @@ class Mali extends Emitter {
    * app.close()
    */
   close () {
-    return pMap(this.servers, s => s.tryShutdownAsync())
+    return pMap(this.servers, s => s.server.tryShutdownAsync())
   }
 
   /**

--- a/lib/app.js
+++ b/lib/app.js
@@ -256,8 +256,11 @@ class Mali extends Emitter {
    * @return {Object} server - The <code>grpc.Server</code> instance
    * @example
    * app.start('localhost:50051')
+   * @example <caption>Start same app on multiple ports</caption>
+   * app.start('0.0.0.0:50050')
+   * app.start('0.0.0.0:50051')
    */
-  start (port, creds = null) {
+  start (port, creds) {
     if (_.isObject(port) && !creds) {
       creds = port
       port = null
@@ -269,7 +272,7 @@ class Mali extends Emitter {
 
     const server = new this.grpc.Server()
     server.tryShutdownAsync = pify(server.tryShutdown)
-    if (!creds) {
+    if (!creds || !_.isObject(creds)) {
       creds = this.grpc.ServerCredentials.createInsecure()
     }
 
@@ -338,6 +341,13 @@ class Mali extends Emitter {
    * @memberof Mali#
    * @example
    * console.log(app.env) // 'development'
+   */
+
+  /**
+   * @member {Array} ports The ports of the started service(s)
+   * @memberof Mali#
+   * @example
+   * console.log(app.ports) // [ 52239 ]
    */
 
   /**

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -85,7 +85,7 @@ test.cb('app.start() with a default port from OS with object param', t => {
   app.close().then(() => t.end())
 })
 
-test.cb('app.start() with a default port from OS with "0.0.0.0:0"', t => {
+test.cb('app.start() with a default port from OS with "127.0.0.1:0"', t => {
   t.plan(5)
   const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
 
@@ -96,7 +96,7 @@ test.cb('app.start() with a default port from OS with "0.0.0.0:0"', t => {
   const app = new Mali(PROTO_PATH, 'Greeter')
   t.truthy(app)
   app.use({ sayHello })
-  const server = app.start('0.0.0.0:0')
+  const server = app.start('127.0.0.1:0')
   t.truthy(server)
   const ports = app.ports
   t.truthy(ports)
@@ -117,7 +117,7 @@ test.cb('app.start() with param', t => {
   const app = new Mali(PROTO_PATH, 'Greeter')
   t.truthy(app)
   app.use({ sayHello })
-  const server = app.start(`0.0.0.0:0${PORT}`)
+  const server = app.start(`127.0.0.1:0${PORT}`)
   t.truthy(server)
   const ports = app.ports
   t.truthy(ports)

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -105,6 +105,26 @@ test.cb('app.start() with a default port from OS with "127.0.0.1:0"', t => {
   app.close().then(() => t.end())
 })
 
+test.cb('app.start() with a default port from OS with ""', t => {
+  t.plan(5)
+  const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
+
+  function sayHello (ctx) {
+    ctx.res = { message: 'Hello ' + ctx.req.name }
+  }
+
+  const app = new Mali(PROTO_PATH, 'Greeter')
+  t.truthy(app)
+  app.use({ sayHello })
+  const server = app.start('')
+  t.truthy(server)
+  const ports = app.ports
+  t.truthy(ports)
+  t.is(ports.length, 1)
+  t.true(typeof ports[0] === 'number')
+  app.close().then(() => t.end())
+})
+
 test.cb('app.start() with param', t => {
   t.plan(5)
   const PORT = tu.getPort()
@@ -118,6 +138,27 @@ test.cb('app.start() with param', t => {
   t.truthy(app)
   app.use({ sayHello })
   const server = app.start(`127.0.0.1:0${PORT}`)
+  t.truthy(server)
+  const ports = app.ports
+  t.truthy(ports)
+  t.is(ports.length, 1)
+  t.is(ports[0], PORT)
+  app.close().then(() => t.end())
+})
+
+test.cb('app.start() with port param and invalid creds', t => {
+  t.plan(5)
+  const PORT = tu.getPort()
+  const PROTO_PATH = path.resolve(__dirname, './protos/helloworld.proto')
+
+  function sayHello (ctx) {
+    ctx.res = { message: 'Hello ' + ctx.req.name }
+  }
+
+  const app = new Mali(PROTO_PATH, 'Greeter')
+  t.truthy(app)
+  app.use({ sayHello })
+  const server = app.start(`127.0.0.1:0${PORT}`, 'foo')
   t.truthy(server)
   const ports = app.ports
   t.truthy(ports)

--- a/test/util.js
+++ b/test/util.js
@@ -5,7 +5,7 @@ function getPort () {
 }
 
 function getHostport (port) {
-  return '0.0.0.0:'.concat(port || getPort())
+  return '127.0.0.1:'.concat(port || getPort())
 }
 
 exports.getHost = getHostport


### PR DESCRIPTION
Implement support for dynamic OS-assigned ports. Fixes #20.

A server can be started on OS-assigned dynamic port by ommiting the hostname parameter completely or by setting the "port" part of the hostname to `0`. All following examples will start a service on an OS-assigned port.

```
app.start()
app.start('')
app.start(grpc.ServerCredentials.createInsecure())
app.start('127.0.0.1:0')
```

The application ports can be be retreived using the `ports()` function:

```
console.log(app.ports()) // [ 50051 ]
```

A single application can be started on multiple ports:

```js
const app = new Mali(PROTO_PATH)
app.use({ sayHello })
const server1 = app.start('127.0.0.1:50051')
const server2 = app.start('127.0.0.1:50052')
console.log(app.ports()) // [ 50051, 50052 ]
```