### PR TITLE
Add index.d.ts to "files"

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,8 @@
     "test": "test"
   },
   "files": [
-    "lib"
+    "lib",
+    "index.d.ts"
   ],
   "ava": {
     "files": [


### PR DESCRIPTION
The currently published package includes `"types": "./index.d.ts"`, but that file was not published due to not being in the "files" list. This should fix it so that future publishes will include `index.d.ts`.