### PR TITLE
Add context attribute mali class typing

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -20,6 +20,7 @@ declare class Mali extends EventEmitter {
   env: string;
   ports: ReadonlyArray<number>;
   silent: boolean;
+  context: any
 
   addService (path: any, name: string | ReadonlyArray<string>, options?: any): void;
   use (service?: any, name?: any, fns?: any): void;


### PR DESCRIPTION
Mali allows dynamically adding new keys to the application context e.g. (`app.context.db = Client()`)

The current TypeScript typing doesn't allow this to happen since the Mali class is missing the context attribute. This change will allow TypeScript users to use the app context the way to docs suggest