### PR TITLE
@grpc/proto-loader on demand

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -4,7 +4,6 @@ const Emitter = require('events')
 const compose = require('@malijs/compose')
 const grpc = require('grpc')
 const pMap = require('p-map')
-const pl = require('@grpc/proto-loader')
 
 const _ = require('./lo')
 const Context = require('./context')
@@ -92,6 +91,7 @@ class Mali extends Emitter {
         }
       }
 
+      const pl = require('@grpc/proto-loader')
       const pd = pl.loadSync(protoFilePath, loadOptions)
       proto = grpc.loadPackageDefinition(pd)
     }


### PR DESCRIPTION
## Issue

`@grpc/proto-loader` isn't needed for all projects, when you use only static protos it isn't needed.

## Solution
- require it only on usage.