### PR TITLE
Optimise traverse

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -99,7 +99,7 @@ class Mali extends Emitter {
     const data = mu.getServiceDefintions(proto)
 
     if (!name) {
-      name = _.keys(data)
+      name = Object.keys(data)
     } else if (_.isString(name)) {
       name = [name]
     }
@@ -190,7 +190,7 @@ class Mali extends Emitter {
       })
     } else if (_.isPlainObject(service)) {
       // we have object notation
-      const testKey = _.keys(service)[0]
+      const testKey = Object.keys(service)[0]
       if (_.isFunction(service[testKey]) || _.isArray(service[testKey])) {
         // first property of object is a function or array
         // that means we have service-level middleware of RPC handlers

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -49,10 +49,11 @@ function getServiceDefintions (proto) {
 
       const shortServiceName = getShortServiceNameFromPath(srviceObj[vKeys[0]].path)
 
-      services[name] = {}
-      services[name].shortServiceName = shortServiceName
-      services[name].fullServiceName = name
-      services[name].service = srviceObj
+      services[name] = {
+        shortServiceName: shortServiceName,
+        fullServiceName: name,
+        service: srviceObj
+      }
 
       const methods = {}
       _.forOwn(srviceObj, (m, k) => {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -64,6 +64,8 @@ function getServiceDefintions (proto) {
       })
 
       services[name].methods = methods
+    } else if (v && v.type) {
+      this.update(v, true)
     }
   })
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -57,11 +57,17 @@ function getServiceDefintions (proto) {
 
       const methods = {}
       _.forOwn(srviceObj, (m, k) => {
-        methods[m.path] = _.pick(m, METHOD_PROPS)
-        methods[m.path].name = getMethodNameFromPath(m.path)
-        methods[m.path].fullName = m.path
-        methods[m.path].package = getPackageNameFromPath(m.path)
-        methods[m.path].service = shortServiceName
+        methods[m.path] = METHOD_PROPS.reduce((acc, method) => {
+          if (method !== 'name') {
+            acc[method] = m[method]
+          }
+          return acc
+        }, {
+          name: getMethodNameFromPath(m.path),
+          fullName: m.path,
+          package: getPackageNameFromPath(m.path),
+          service: shortServiceName
+        })
       })
 
       services[name].methods = methods

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -37,36 +37,34 @@ function getCallTypeFromDescriptor (descriptor) {
 function getServiceDefintions (proto) {
   const services = {}
 
-  traverse(proto).forEach(function (v0) {
-    traverse(v0).forEach(function (v) {
-      if (isService(v)) {
-        const srviceObj = v.service || v
-        const vKeys = _.keys(srviceObj)
-        const name = getServiceNameFromPath(srviceObj[vKeys[0]].path)
+  traverse(proto).forEach(function (v) {
+    if (isService(v)) {
+      const srviceObj = v.service || v
+      const vKeys = _.keys(srviceObj)
+      const name = getServiceNameFromPath(srviceObj[vKeys[0]].path)
 
-        if (services[name]) {
-          return
-        }
-
-        const shortServiceName = getShortServiceNameFromPath(srviceObj[vKeys[0]].path)
-
-        services[name] = {}
-        services[name].shortServiceName = shortServiceName
-        services[name].fullServiceName = name
-        services[name].service = srviceObj
-
-        const methods = {}
-        _.forOwn(srviceObj, (m, k) => {
-          methods[m.path] = _.pick(m, METHOD_PROPS)
-          methods[m.path].name = getMethodNameFromPath(m.path)
-          methods[m.path].fullName = m.path
-          methods[m.path].package = getPackageNameFromPath(m.path)
-          methods[m.path].service = shortServiceName
-        })
-
-        services[name].methods = methods
+      if (services[name]) {
+        return
       }
-    })
+
+      const shortServiceName = getShortServiceNameFromPath(srviceObj[vKeys[0]].path)
+
+      services[name] = {}
+      services[name].shortServiceName = shortServiceName
+      services[name].fullServiceName = name
+      services[name].service = srviceObj
+
+      const methods = {}
+      _.forOwn(srviceObj, (m, k) => {
+        methods[m.path] = _.pick(m, METHOD_PROPS)
+        methods[m.path].name = getMethodNameFromPath(m.path)
+        methods[m.path].fullName = m.path
+        methods[m.path].package = getPackageNameFromPath(m.path)
+        methods[m.path].service = shortServiceName
+      })
+
+      services[name].methods = methods
+    }
   })
 
   return services

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -72,6 +72,7 @@ function getServiceDefintions (proto) {
 
       services[name].methods = methods
     } else if (v && v.type) {
+      // Skip children
       this.update(v, true)
     }
   })

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -40,7 +40,7 @@ function getServiceDefintions (proto) {
   traverse(proto).forEach(function (v) {
     if (isService(v)) {
       const srviceObj = v.service || v
-      const vKeys = _.keys(srviceObj)
+      const vKeys = Object.keys(srviceObj)
       const name = getServiceNameFromPath(srviceObj[vKeys[0]].path)
 
       if (services[name]) {
@@ -105,12 +105,12 @@ function getShortServiceNameFromPath (path) {
 
 function isService (v) {
   if (v && v.service) {
-    const vKeys = _.keys(v.service)
+    const vKeys = Object.keys(v.service)
 
     return vKeys && vKeys.length && v.service[vKeys[0]] && v.service[vKeys[0]].path &&
       _.isString(v.service[vKeys[0]].path) && v.service[vKeys[0]].path[0] === '/'
   } else if (v) {
-    const vKeys = _.keys(v)
+    const vKeys = Object.keys(v)
 
     return vKeys && vKeys.length && v[vKeys[0]] && v[vKeys[0]].path &&
       _.isString(v[vKeys[0]].path) && v[vKeys[0]].path[0] === '/'


### PR DESCRIPTION
I am using mali and I noticed the start up time was quite slow. I traced it down to the traverse method which appears to be traversing values that it doesn't need to. I don't know when it became slow, but my theory is the migration to using @grpc/grpc-js which likely exposes more properties as an JavaScript object and therefore are being traversed. Please see the commit messages for more details.

I would also like to extend my thanks for providing this software.