### PR TITLE
Improve boot performance

### DIFF
--- a/lib/app.js
+++ b/lib/app.js
@@ -185,22 +185,22 @@ class Mali extends Emitter {
           sd.middleware = _.concat(sd.middleware, service, fns)
         }
       })
-    } else if (_.isPlainObject(service)) {
+    } else if (typeof service === 'object') {
       // we have object notation
       const testKey = Object.keys(service)[0]
       if (_.isFunction(service[testKey]) || _.isArray(service[testKey])) {
         // first property of object is a function or array
         // that means we have service-level middleware of RPC handlers
 
-        _.forOwn(service, (val, key) => {
+        for (const key in service) {
           // lets try to match the key to any service name first
+          const val = service[key]
           const serviceName = this._getMatchingServiceName(key)
 
           if (serviceName) {
             // we have a matching service
             // lets add service-level middleware to that service
-            const sd = this.data[serviceName]
-            sd.middleware = _.concat(sd.middleware, val)
+            this.data[serviceName].middleware.push(val)
           } else {
             // we need to find the matching function to set it as handler
             const { serviceName, methodName } = this._getMatchingCall(key)
@@ -215,24 +215,25 @@ class Mali extends Emitter {
               throw new TypeError(`Unknown method: ${key}`)
             }
           }
-        })
-      } else if (_.isObject(service[testKey])) {
-        _.forOwn(service, (def, serviceName) => {
-          _.forOwn(def, (mw, mwName) => {
-            if (_.isFunction(mw)) {
-              this.use(serviceName, mwName, mw)
-            } else if (_.isArray(mw)) {
-              this.use(serviceName, mwName, ...mw)
+        }
+      } else if (typeof service[testKey] === 'object') {
+        for (const serviceName in service) {
+          for (const middlewareName in service[serviceName]) {
+            const middleware = service[serviceName][middlewareName]
+            if (_.isFunction(middleware)) {
+              this.use(serviceName, middlewareName, middleware)
+            } else if (_.isArray(middleware)) {
+              this.use(serviceName, middlewareName, ...middleware)
             } else {
-              throw new TypeError(`Handler for ${mwName} is not a function or array`)
+              throw new TypeError(`Handler for ${middlewareName} is not a function or array`)
             }
-          })
-        })
+          }
+        }
       } else {
         throw new TypeError(`Invalid type for handler for ${testKey}`)
       }
     } else {
-      if (!_.isString(name)) {
+      if (typeof name !== 'string') {
         // name is a function pre-pand it to fns
         fns.unshift(name)
 
@@ -486,11 +487,12 @@ class Mali extends Emitter {
         serviceName = key
       }
     } else {
-      _.forOwn(this.data, (sd, sn) => {
-        if (!serviceName && (sn === key || sn.endsWith('.' + key))) {
+      for (const sn in this.data) {
+        if (sn === key || sn.endsWith('.' + key)) {
           serviceName = sn
+          break
         }
-      })
+      }
     }
 
     return serviceName
@@ -524,8 +526,8 @@ class Mali extends Emitter {
   _matchesHandlerName (handlerObj, handlerName, testValue) {
     return handlerName === testValue ||
       handlerName.endsWith('/' + testValue) ||
-      (handlerObj && handlerObj.originalName === testValue) ||
-      (handlerObj && handlerObj.name === testValue) ||
+      (handlerObj?.originalName === testValue) ||
+      (handlerObj?.name === testValue) ||
       (handlerObj && _.camelCase(handlerObj.name) === _.camelCase(testValue))
   }
 }

--- a/lib/app.js
+++ b/lib/app.js
@@ -177,16 +177,14 @@ class Mali extends Emitter {
     if (_.isFunction(service)) {
       const isFunction = _.isFunction(name)
 
-      for (const sn in this.data) {
-        const sd = this.data[sn]
-
-        sd.middleware.push(service)
+      for (const serviceName in this.data) {
+        const _service = this.data[serviceName]
 
         if (isFunction) {
-          sd.middleware.push(name)
+          _service.middleware = _service.middleware.concat(service, name, fns)
+        } else {
+          _service.middleware = _service.middleware.concat(service, fns)
         }
-
-        sd.middleware.push(fns)
       }
     } else if (typeof service === 'object') {
       // we have object notation

--- a/lib/app.js
+++ b/lib/app.js
@@ -175,16 +175,19 @@ class Mali extends Emitter {
    */
   use (service, name, ...fns) {
     if (_.isFunction(service)) {
-      // service is a function
-      // apply global middlware
+      const isFunction = _.isFunction(name)
 
-      _.forOwn(this.data, (sd, sn) => {
-        if (_.isFunction(name)) { // make sure name is given and is also a function
-          sd.middleware = _.concat(sd.middleware, service, name, fns)
-        } else {
-          sd.middleware = _.concat(sd.middleware, service, fns)
+      for (const sn in this.data) {
+        const sd = this.data[sn]
+
+        sd.middleware.push(service)
+
+        if (isFunction) {
+          sd.middleware.push(name)
         }
-      })
+
+        sd.middleware.push(fns)
+      }
     } else if (typeof service === 'object') {
       // we have object notation
       const testKey = Object.keys(service)[0]

--- a/lib/app.js
+++ b/lib/app.js
@@ -480,23 +480,17 @@ class Mali extends Emitter {
    * gets matching service name
    */
   _getMatchingServiceName (key) {
-    let serviceName
-    if (key.indexOf('.') > 0) {
-      // we have full path
+    if (this.data[key]) {
+      return key
+    }
 
-      if (this.data[key]) {
-        serviceName = key
-      }
-    } else {
-      for (const sn in this.data) {
-        if (sn === key || sn.endsWith('.' + key)) {
-          serviceName = sn
-          break
-        }
+    for (const serviceName in this.data) {
+      if (serviceName.endsWith('.' + key)) {
+        return serviceName
       }
     }
 
-    return serviceName
+    return null
   }
 
   /*!

--- a/lib/app.js
+++ b/lib/app.js
@@ -103,29 +103,25 @@ class Mali extends Emitter {
       name = [name]
     }
 
-    const picked = {}
-
     for (const k in data) {
       const v = data[k]
 
-      if (name.includes(k) || name.includes(v.shortServiceName)) {
-        picked[k] = v
+      if (name.indexOf(k) >= 0 || name.indexOf(v.shortServiceName) >= 0) {
+        v.middleware = []
+        v.handlers = {}
+
+        for (const method in v.methods) {
+          v.handlers[method] = null
+        }
+
+        this.data[k] = v
       }
     }
 
-    for (const k in picked) {
-      picked[k].middleware = []
-      picked[k].handlers = {}
-
-      for (const method in picked[k].methods) {
-        picked[k].handlers[method] = null
+    if (!this.name) {
+      if (Array.isArray(name)) {
+        this.name = name[0]
       }
-    }
-
-    Object.assign(this.data, picked)
-
-    if (!this.name && Array.isArray(name)) {
-      this.name = name[0]
     }
   }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -3,6 +3,7 @@ const assert = require('assert')
 const Emitter = require('events')
 const compose = require('@malijs/compose')
 const grpc = require('@grpc/grpc-js')
+const protoLoader = require('@grpc/proto-loader')
 
 const _ = require('./lo')
 const Context = require('./context')
@@ -81,7 +82,7 @@ class Mali extends Emitter {
     let proto = path
     if (load) {
       let protoFilePath = path
-      const loadOptions = _.assign({}, options)
+      const loadOptions = Object.assign({}, options)
 
       if (_.isObject(path) && path.root && path.file) {
         protoFilePath = path.file
@@ -90,8 +91,7 @@ class Mali extends Emitter {
         }
       }
 
-      const pl = require('@grpc/proto-loader')
-      const pd = pl.loadSync(protoFilePath, loadOptions)
+      const pd = protoLoader.loadSync(protoFilePath, loadOptions)
       proto = grpc.loadPackageDefinition(pd)
     }
 
@@ -104,26 +104,28 @@ class Mali extends Emitter {
     }
 
     const picked = {}
-    _.forOwn(data, (v, k) => {
-      if (name.indexOf(k) >= 0 || name.indexOf(v.shortServiceName) >= 0) {
+
+    for (const k in data) {
+      const v = data[k]
+
+      if (name.includes(k) || name.includes(v.shortServiceName)) {
         picked[k] = v
       }
-    })
+    }
 
-    _.forOwn(picked, (v, k) => {
-      v.middleware = []
-      v.handlers = {}
-      _.forOwn(v.methods, (method, methodName) => {
-        v.handlers[methodName] = null
-      })
-    })
+    for (const k in picked) {
+      picked[k].middleware = []
+      picked[k].handlers = {}
 
-    this.data = _.assign(this.data, picked)
-
-    if (!this.name) {
-      if (Array.isArray(name)) {
-        this.name = name[0]
+      for (const method in picked[k].methods) {
+        picked[k].handlers[method] = null
       }
+    }
+
+    Object.assign(this.data, picked)
+
+    if (!this.name && Array.isArray(name)) {
+      this.name = name[0]
     }
   }
 

--- a/lib/app.js
+++ b/lib/app.js
@@ -77,14 +77,14 @@ class Mali extends Emitter {
    * @param {Object} options - Options to be passed to <code>grpc.load</code>
    */
   addService (path, name, options) {
-    const load = _.isString(path) || (_.isObject(path) && path.root && path.file)
+    const load = typeof path === 'string' || (_.isObject(path) && path.root && path.file)
 
     let proto = path
     if (load) {
       let protoFilePath = path
       const loadOptions = Object.assign({}, options)
 
-      if (_.isObject(path) && path.root && path.file) {
+      if (typeof path === 'object' && path.root && path.file) {
         protoFilePath = path.file
         if (!loadOptions.includeDirs) {
           loadOptions.includeDirs = [path.root]
@@ -99,7 +99,7 @@ class Mali extends Emitter {
 
     if (!name) {
       name = Object.keys(data)
-    } else if (_.isString(name)) {
+    } else if (typeof name === 'string') {
       name = [name]
     }
 
@@ -174,8 +174,8 @@ class Mali extends Emitter {
    * })
    */
   use (service, name, ...fns) {
-    if (_.isFunction(service)) {
-      const isFunction = _.isFunction(name)
+    if (typeof service === 'function') {
+      const isFunction = typeof name === 'function'
 
       for (const serviceName in this.data) {
         const _service = this.data[serviceName]
@@ -189,7 +189,7 @@ class Mali extends Emitter {
     } else if (typeof service === 'object') {
       // we have object notation
       const testKey = Object.keys(service)[0]
-      if (_.isFunction(service[testKey]) || _.isArray(service[testKey])) {
+      if (typeof service[testKey] === 'function' || Array.isArray(service[testKey])) {
         // first property of object is a function or array
         // that means we have service-level middleware of RPC handlers
 
@@ -207,7 +207,7 @@ class Mali extends Emitter {
             const { serviceName, methodName } = this._getMatchingCall(key)
 
             if (serviceName && methodName) {
-              if (_.isFunction(val)) {
+              if (typeof val === 'function') {
                 this.use(serviceName, methodName, val)
               } else {
                 this.use(serviceName, methodName, ...val)
@@ -221,9 +221,9 @@ class Mali extends Emitter {
         for (const serviceName in service) {
           for (const middlewareName in service[serviceName]) {
             const middleware = service[serviceName][middlewareName]
-            if (_.isFunction(middleware)) {
+            if (typeof middleware === 'function') {
               this.use(serviceName, middlewareName, middleware)
-            } else if (_.isArray(middleware)) {
+            } else if (Array.isArray(middleware)) {
               this.use(serviceName, middlewareName, ...middleware)
             } else {
               throw new TypeError(`Handler for ${middlewareName} is not a function or array`)
@@ -246,7 +246,7 @@ class Mali extends Emitter {
           // we have a matching service
           // lets add service-level middleware to that service
           const sd = this.data[serviceName]
-          sd.middleware = _.concat(sd.middleware, fns)
+          sd.middleware = sd.middleware.concat(fns)
 
           return
         } else {
@@ -290,7 +290,7 @@ class Mali extends Emitter {
         throw new Error(`Handler for ${name} already defined for service ${serviceName}`)
       }
 
-      sd.handlers[methodName] = _.concat(sd.middleware, fns)
+      sd.handlers[methodName] = sd.middleware.concat(fns)
     }
   }
 
@@ -342,7 +342,7 @@ class Mali extends Emitter {
       port = null
     }
 
-    if (!port || !_.isString(port) || (_.isString(port) && port.length === 0)) {
+    if (!port || typeof port !== 'string' || (typeof port === 'string' && port.length === 0)) {
       port = '127.0.0.1:0'
     }
 
@@ -359,7 +359,7 @@ class Mali extends Emitter {
       const composed = {}
       const { methods, handlers } = sd
 
-      let handlerValues = _.values(handlers)
+      let handlerValues = Object.values(handlers)
       handlerValues = _.compact(handlerValues)
       const hasHandlers = handlerValues && handlerValues.length
 

--- a/lib/lo.js
+++ b/lib/lo.js
@@ -1,5 +1,4 @@
 const forOwn = require('lodash.forown')
-const concat = require('lodash.concat')
 const isPlainObject = require('lodash.isplainobject')
 const pull = require('lodash.pull')
 const pick = require('lodash.pick')
@@ -7,19 +6,12 @@ const camelCase = require('lodash.camelcase')
 
 module.exports = {
   forOwn,
-  concat,
   isPlainObject,
   pull,
   pick,
   camelCase,
-  isArray: Array.isArray,
-  keys: Object.keys,
   assign: Object.assign,
-  isString: (value) => typeof value === 'string',
   isObject: (value) => value != null && (typeof value === 'object' || typeof value === 'function'),
-  isFunction: (value) => typeof value === 'function',
   upperFirst: (value) => value ? value.charAt(0).toUpperCase() + value.slice(1) : '',
-  values: Object.values,
-  find: (value, callback) => value.find(callback),
   compact: (values) => values.filter(v => !!v)
 }

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -9,11 +9,9 @@ const grpc = require('@grpc/grpc-js')
  * Note that <code>Metadata</code> only accept string or buffer values.
  * @param  {Object} metadata Plain javascript object to tranform into <code>Metadata</code>
  *                           If an instance of <code>Metadata</code> is passed in it is simply returned
- * @param  {Object} options options
- * @param  {Boolean} options.addEmpty whether to add empty strings. Default: <code>false</code>
  * @return {Metadata} An instance of <code>Metadata</code>, or `undefined` if input is not an object
  */
-module.exports = function create (metadata, options) {
+module.exports = function create (metadata) {
   if (typeof metadata !== 'object') {
     return
   }
@@ -24,7 +22,8 @@ module.exports = function create (metadata, options) {
 
   const meta = new grpc.Metadata()
 
-  for (const [k, v] of Object.entries(metadata)) {
+  for (const k in metadata) {
+    const v = metadata[k]
     if (Buffer.isBuffer(v)) {
       if (!k.endsWith('-bin')) {
         throw new Error(`Metadata key "${k}" should end with "-bin" since it has a non-string value.`)
@@ -32,7 +31,7 @@ module.exports = function create (metadata, options) {
       meta.add(k, v)
     } else if (v !== null && typeof v !== 'undefined') {
       const toAdd = typeof v === 'string' ? v : v.toString()
-      if (toAdd?.length > 0 || (options?.addEmpty)) {
+      if (toAdd) {
         meta.add(k, toAdd)
       }
     }

--- a/lib/metadata.js
+++ b/lib/metadata.js
@@ -1,0 +1,42 @@
+const grpc = require('@grpc/grpc-js')
+
+/**
+ * Utility helper function to create <code>Metadata</code> object from plain Javascript object
+ * This strictly just calls <code>Metadata.add</code> with the key / value map of objects.
+ * If the value is a <code>Buffer</code> it's passed as is.
+ * If the value is a <code>Sting</code> it's passed as is.
+ * Else if the value defined and not a string we simply call <code>toString()</code>.
+ * Note that <code>Metadata</code> only accept string or buffer values.
+ * @param  {Object} metadata Plain javascript object to tranform into <code>Metadata</code>
+ *                           If an instance of <code>Metadata</code> is passed in it is simply returned
+ * @param  {Object} options options
+ * @param  {Boolean} options.addEmpty whether to add empty strings. Default: <code>false</code>
+ * @return {Metadata} An instance of <code>Metadata</code>, or `undefined` if input is not an object
+ */
+module.exports = function create (metadata, options) {
+  if (typeof metadata !== 'object') {
+    return
+  }
+
+  if (metadata instanceof grpc.Metadata) {
+    return metadata
+  }
+
+  const meta = new grpc.Metadata()
+
+  for (const [k, v] of Object.entries(metadata)) {
+    if (Buffer.isBuffer(v)) {
+      if (!k.endsWith('-bin')) {
+        throw new Error(`Metadata key "${k}" should end with "-bin" since it has a non-string value.`)
+      }
+      meta.add(k, v)
+    } else if (v !== null && typeof v !== 'undefined') {
+      const toAdd = typeof v === 'string' ? v : v.toString()
+      if (toAdd?.length > 0 || (options?.addEmpty)) {
+        meta.add(k, toAdd)
+      }
+    }
+  }
+
+  return meta
+}

--- a/lib/request.js
+++ b/lib/request.js
@@ -1,6 +1,6 @@
 const grpc = require('@grpc/grpc-js')
 const CallType = require('@malijs/call-types')
-const create = require('grpc-create-metadata')
+const create = require('./metadata')
 
 /**
  * Mali Request class that encapsulates the request of a call.

--- a/lib/request.js
+++ b/lib/request.js
@@ -34,7 +34,7 @@ class Request {
    * @return {Object} request metadata
    */
   getMetadata () {
-    return create(this.metadata, { addEmpty: false })
+    return create(this.metadata)
   }
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -71,7 +71,7 @@ class Response {
    * @return {Object} response metadata
    */
   getMetadata () {
-    return create(this.metadata, { addEmpty: false })
+    return create(this.metadata)
   }
 
   /**

--- a/lib/response.js
+++ b/lib/response.js
@@ -1,6 +1,6 @@
 const grpc = require('@grpc/grpc-js')
 const CallType = require('@malijs/call-types')
-const create = require('grpc-create-metadata')
+const create = require('./metadata')
 
 const _ = require('./lo')
 

--- a/lib/response.js
+++ b/lib/response.js
@@ -2,8 +2,6 @@ const grpc = require('@grpc/grpc-js')
 const CallType = require('@malijs/call-types')
 const create = require('./metadata')
 
-const _ = require('./lo')
-
 /**
  * Mali Response class that encapsulates the response of a call.
  * Clients to not create this. Mali does it for us.
@@ -43,7 +41,7 @@ class Response {
     } else {
       const md = field instanceof grpc.Metadata ? field.getMap() : field
 
-      if (_.isObject(md)) {
+      if (typeof md === 'object') {
         for (const key in md) {
           this.set(key, md[key])
         }
@@ -90,7 +88,7 @@ class Response {
    */
   sendMetadata (md) {
     // if forcing send reset our metadata
-    if (md && (_.isObject(md) || md instanceof grpc.Metadata)) {
+    if (md && (typeof md === 'object' || md instanceof grpc.Metadata)) {
       this.metadata = null
       this.set(md)
     }
@@ -136,7 +134,7 @@ class Response {
     } else {
       const md = field instanceof grpc.Metadata ? field.getMap() : field
 
-      if (_.isObject(md)) {
+      if (typeof md === 'object') {
         for (const key in md) {
           this.setStatus(key, md[key])
         }

--- a/lib/run.js
+++ b/lib/run.js
@@ -17,7 +17,7 @@ function onEnd (s, fn) {
 function wrapEnd (ctx) {
   const endFn = ctx.call.end
   ctx.call.end = function end (statusMetadata) {
-    return endFn.call(ctx.call, create(statusMetadata, { addEmpty: false }) || ctx.response.getStatusMetadata())
+    return endFn.call(ctx.call, create(statusMetadata) || ctx.response.getStatusMetadata())
   }
 }
 

--- a/lib/run.js
+++ b/lib/run.js
@@ -3,7 +3,7 @@ const CallType = require('@malijs/call-types')
 const destroy = require('destroy')
 const first = require('ee-first')
 const stream = require('stream')
-const create = require('grpc-create-metadata')
+const create = require('./metadata')
 
 function onEnd (s, fn) {
   const ee = first([

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,8 +1,6 @@
 const traverse = require('traverse')
 const CallType = require('@malijs/call-types')
 
-const _ = require('./lo')
-
 const METHOD_PROPS = ['name', 'options', 'type', 'requestStream', 'responseStream',
   'requestName', 'responseName', 'path', 'requestType', 'responseType', 'originalName']
 
@@ -113,12 +111,12 @@ function isService (v) {
     const vKeys = Object.keys(v.service)
 
     return vKeys.length > 0 && v.service[vKeys[0]] && v.service[vKeys[0]].path &&
-      _.isString(v.service[vKeys[0]].path) && v.service[vKeys[0]].path[0] === '/'
+      typeof v.service[vKeys[0]].path === 'string' && v.service[vKeys[0]].path[0] === '/'
   } else if (v) {
     const vKeys = Object.keys(v)
 
     return vKeys.length > 0 && v[vKeys[0]] && v[vKeys[0]].path &&
-      _.isString(v[vKeys[0]].path) && v[vKeys[0]].path[0] === '/'
+      typeof v[vKeys[0]].path === 'string' && v[vKeys[0]].path[0] === '/'
   }
 
   return false

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -9,13 +9,13 @@ const METHOD_PROPS = ['name', 'options', 'type', 'requestStream', 'responseStrea
 function getCallTypeFromCall (call) {
   const name = Object.getPrototypeOf(call)?.constructor?.name ?? ''
 
-  if (name.startsWith('ServerUnaryCall')) {
+  if (name.indexOf('ServerUnaryCall') === 0) {
     return CallType.UNARY
-  } else if (name.startsWith('ServerWritableStream')) {
+  } else if (name.indexOf('ServerWritableStream') === 0) {
     return CallType.RESPONSE_STREAM
-  } else if (name.startsWith('ServerReadableStream')) {
+  } else if (name.indexOf('ServerReadableStream') === 0) {
     return CallType.REQUEST_STREAM
-  } else if (name.startsWith('ServerDuplexStream')) {
+  } else if (name.indexOf('ServerDuplexStream') === 0) {
     return CallType.DUPLEX
   }
 }
@@ -50,12 +50,13 @@ function getServiceDefintions (proto) {
       services[name] = {
         shortServiceName: shortServiceName,
         fullServiceName: name,
-        service: srviceObj
+        service: srviceObj,
+        methods: {}
       }
 
-      const methods = {}
-      _.forOwn(srviceObj, (m, k) => {
-        methods[m.path] = METHOD_PROPS.reduce((acc, method) => {
+      for (const k in srviceObj) {
+        const m = srviceObj[k]
+        services[name].methods[m.path] = METHOD_PROPS.reduce((acc, method) => {
           if (method !== 'name') {
             acc[method] = m[method]
           }
@@ -66,9 +67,7 @@ function getServiceDefintions (proto) {
           package: getPackageNameFromPath(m.path),
           service: shortServiceName
         })
-      })
-
-      services[name].methods = methods
+      }
     } else if (v && v.type) {
       // Skip children
       this.update(v, true)
@@ -113,12 +112,12 @@ function isService (v) {
   if (v && v.service) {
     const vKeys = Object.keys(v.service)
 
-    return vKeys && vKeys.length && v.service[vKeys[0]] && v.service[vKeys[0]].path &&
+    return vKeys.length > 0 && v.service[vKeys[0]] && v.service[vKeys[0]].path &&
       _.isString(v.service[vKeys[0]].path) && v.service[vKeys[0]].path[0] === '/'
   } else if (v) {
     const vKeys = Object.keys(v)
 
-    return vKeys && vKeys.length && v[vKeys[0]] && v[vKeys[0]].path &&
+    return vKeys.length > 0 && v[vKeys[0]] && v[vKeys[0]].path &&
       _.isString(v[vKeys[0]].path) && v[vKeys[0]].path[0] === '/'
   }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,6 @@
         "delegates": "^1.0.0",
         "destroy": "^1.0.4",
         "ee-first": "^1.1.1",
-        "grpc-create-metadata": "^4.0.0",
         "lodash.camelcase": "^4.3.0",
         "lodash.concat": "^4.5.0",
         "lodash.forown": "^4.4.0",
@@ -3179,14 +3178,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
-    },
-    "node_modules/grpc-create-metadata": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/grpc-create-metadata/-/grpc-create-metadata-4.0.0.tgz",
-      "integrity": "sha512-fT333mIwtA1nqcwrrNs9tLy9MQZYq+g7H7+IQvQCbaEqNLrPTBUd3iD2KostnyGRZ//g8WAaVWR06O33LxUITg==",
-      "dependencies": {
-        "lodash.forown": "^4.4.0"
-      }
     },
     "node_modules/handlebars": {
       "version": "4.7.7",
@@ -9733,14 +9724,6 @@
       "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.6.tgz",
       "integrity": "sha512-nTnJ528pbqxYanhpDYsi4Rd8MAeaBA67+RZ10CM1m3bTAVFEDcd5AuA4a6W5YkGZ1iNXHzZz8T6TBKLeBuNriQ==",
       "dev": true
-    },
-    "grpc-create-metadata": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/grpc-create-metadata/-/grpc-create-metadata-4.0.0.tgz",
-      "integrity": "sha512-fT333mIwtA1nqcwrrNs9tLy9MQZYq+g7H7+IQvQCbaEqNLrPTBUd3iD2KostnyGRZ//g8WAaVWR06O33LxUITg==",
-      "requires": {
-        "lodash.forown": "^4.4.0"
-      }
     },
     "handlebars": {
       "version": "4.7.7",

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,7 +15,6 @@
         "destroy": "^1.0.4",
         "ee-first": "^1.1.1",
         "lodash.camelcase": "^4.3.0",
-        "lodash.concat": "^4.5.0",
         "lodash.forown": "^4.4.0",
         "lodash.isplainobject": "^4.0.6",
         "lodash.pick": "^4.4.0",
@@ -24,7 +23,7 @@
       },
       "devDependencies": {
         "@grpc/grpc-js": "^1.3.2",
-        "@grpc/proto-loader": "^0.6.1",
+        "@grpc/proto-loader": "^0.6.2",
         "async": "^3.2.0",
         "ava": "^3.15.0",
         "benchmarkify": "^2.1.3",
@@ -4389,11 +4388,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "node_modules/lodash.concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.concat/-/lodash.concat-4.5.0.tgz",
-      "integrity": "sha1-sFOuAuSoAIWC5yVrnQK9ptA4A5U="
     },
     "node_modules/lodash.flattendeep": {
       "version": "4.4.0",
@@ -10863,11 +10857,6 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz",
       "integrity": "sha1-soqmKIorn8ZRA1x3EfZathkDMaY="
-    },
-    "lodash.concat": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/lodash.concat/-/lodash.concat-4.5.0.tgz",
-      "integrity": "sha1-sFOuAuSoAIWC5yVrnQK9ptA4A5U="
     },
     "lodash.flattendeep": {
       "version": "4.4.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
         "@grpc/proto-loader": "^0.6.1",
         "async": "^3.2.0",
         "ava": "^3.15.0",
+        "benchmark": "^2.1.4",
         "coveralls": "^3.1.0",
         "google-protobuf": "^3.17.3",
         "highland": "3.0.0-beta.10",
@@ -1097,6 +1098,16 @@
       "dev": true,
       "dependencies": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "node_modules/benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "dependencies": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "node_modules/binary-extensions": {
@@ -5211,6 +5222,12 @@
         "node": ">=8"
       }
     },
+    "node_modules/platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
+    },
     "node_modules/plur": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -8023,6 +8040,16 @@
       "dev": true,
       "requires": {
         "tweetnacl": "^0.14.3"
+      }
+    },
+    "benchmark": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
+      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+      "dev": true,
+      "requires": {
+        "lodash": "^4.17.4",
+        "platform": "^1.3.3"
       }
     },
     "binary-extensions": {
@@ -11326,6 +11353,12 @@
       "requires": {
         "find-up": "^4.0.0"
       }
+    },
+    "platform": {
+      "version": "1.3.6",
+      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
+      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
+      "dev": true
     },
     "plur": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,7 @@
         "@grpc/proto-loader": "^0.6.1",
         "async": "^3.2.0",
         "ava": "^3.15.0",
-        "benchmark": "^2.1.4",
+        "benchmarkify": "^2.1.3",
         "coveralls": "^3.1.0",
         "google-protobuf": "^3.17.3",
         "highland": "3.0.0-beta.10",
@@ -1100,14 +1100,175 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "node_modules/benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+    "node_modules/benchmarkify": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/benchmarkify/-/benchmarkify-2.1.3.tgz",
+      "integrity": "sha512-X8RcCkiYueqDD6+LuKbrHTKgIgveQPc6zSXulEwmjb306CUeUU/UcC+gJBXD7Tg+rjvclcOfarIoyCSQ86OzTQ==",
       "dev": true,
       "dependencies": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
+        "bluebird": "^3.5.5",
+        "chalk": "^2.4.2",
+        "lodash": "^4.17.20",
+        "ora": "^3.4.0",
+        "tiny-human-time": "^1.2.0"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/ansi-regex": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+      "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+      "dev": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/ansi-styles": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+      "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+      "dev": true,
+      "dependencies": {
+        "color-convert": "^1.9.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/chalk": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+      "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^3.2.1",
+        "escape-string-regexp": "^1.0.5",
+        "supports-color": "^5.3.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/cli-cursor": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+      "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+      "dev": true,
+      "dependencies": {
+        "restore-cursor": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/color-convert": {
+      "version": "1.9.3",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+      "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "1.1.3"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/color-name": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+      "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+      "dev": true
+    },
+    "node_modules/benchmarkify/node_modules/has-flag": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+      "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/log-symbols": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+      "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/mimic-fn": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+      "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/onetime": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+      "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+      "dev": true,
+      "dependencies": {
+        "mimic-fn": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/ora": {
+      "version": "3.4.0",
+      "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+      "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+      "dev": true,
+      "dependencies": {
+        "chalk": "^2.4.2",
+        "cli-cursor": "^2.1.0",
+        "cli-spinners": "^2.0.0",
+        "log-symbols": "^2.2.0",
+        "strip-ansi": "^5.2.0",
+        "wcwidth": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/restore-cursor": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+      "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+      "dev": true,
+      "dependencies": {
+        "onetime": "^2.0.0",
+        "signal-exit": "^3.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/strip-ansi": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+      "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-regex": "^4.1.0"
+      },
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/benchmarkify/node_modules/supports-color": {
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+      "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/binary-extensions": {
@@ -5222,12 +5383,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
-    },
     "node_modules/plur": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -6623,6 +6778,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+      "dev": true,
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/tiny-human-time": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-human-time/-/tiny-human-time-1.2.0.tgz",
+      "integrity": "sha1-DEpCWUDgU+LTHZA9bwPTjPuXeGA=",
       "dev": true,
       "engines": {
         "node": ">=4"
@@ -8042,14 +8206,141 @@
         "tweetnacl": "^0.14.3"
       }
     },
-    "benchmark": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/benchmark/-/benchmark-2.1.4.tgz",
-      "integrity": "sha1-CfPeMckWQl1JjMLuVloOvzwqVik=",
+    "benchmarkify": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/benchmarkify/-/benchmarkify-2.1.3.tgz",
+      "integrity": "sha512-X8RcCkiYueqDD6+LuKbrHTKgIgveQPc6zSXulEwmjb306CUeUU/UcC+gJBXD7Tg+rjvclcOfarIoyCSQ86OzTQ==",
       "dev": true,
       "requires": {
-        "lodash": "^4.17.4",
-        "platform": "^1.3.3"
+        "bluebird": "^3.5.5",
+        "chalk": "^2.4.2",
+        "lodash": "^4.17.20",
+        "ora": "^3.4.0",
+        "tiny-human-time": "^1.2.0"
+      },
+      "dependencies": {
+        "ansi-regex": {
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+          "integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+          "dev": true
+        },
+        "ansi-styles": {
+          "version": "3.2.1",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+          "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+          "dev": true,
+          "requires": {
+            "color-convert": "^1.9.0"
+          }
+        },
+        "chalk": {
+          "version": "2.4.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+          "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^3.2.1",
+            "escape-string-regexp": "^1.0.5",
+            "supports-color": "^5.3.0"
+          }
+        },
+        "cli-cursor": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
+          "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
+          "dev": true,
+          "requires": {
+            "restore-cursor": "^2.0.0"
+          }
+        },
+        "color-convert": {
+          "version": "1.9.3",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+          "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+          "dev": true,
+          "requires": {
+            "color-name": "1.1.3"
+          }
+        },
+        "color-name": {
+          "version": "1.1.3",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+          "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+          "integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+          "dev": true
+        },
+        "log-symbols": {
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/log-symbols/-/log-symbols-2.2.0.tgz",
+          "integrity": "sha512-VeIAFslyIerEJLXHziedo2basKbMKtTw3vfn5IzG0XTjhAVEJyNHnL2p7vc+wBDSdQuUpNw3M2u6xb9QsAY5Eg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.0.1"
+          }
+        },
+        "mimic-fn": {
+          "version": "1.2.0",
+          "resolved": "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.2.0.tgz",
+          "integrity": "sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==",
+          "dev": true
+        },
+        "onetime": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
+          "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
+          "dev": true,
+          "requires": {
+            "mimic-fn": "^1.0.0"
+          }
+        },
+        "ora": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/ora/-/ora-3.4.0.tgz",
+          "integrity": "sha512-eNwHudNbO1folBP3JsZ19v9azXWtQZjICdr3Q0TDPIaeBQ3mXLrh54wM+er0+hSp+dWKf+Z8KM58CYzEyIYxYg==",
+          "dev": true,
+          "requires": {
+            "chalk": "^2.4.2",
+            "cli-cursor": "^2.1.0",
+            "cli-spinners": "^2.0.0",
+            "log-symbols": "^2.2.0",
+            "strip-ansi": "^5.2.0",
+            "wcwidth": "^1.0.1"
+          }
+        },
+        "restore-cursor": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
+          "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
+          "dev": true,
+          "requires": {
+            "onetime": "^2.0.0",
+            "signal-exit": "^3.0.2"
+          }
+        },
+        "strip-ansi": {
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+          "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
+          "dev": true,
+          "requires": {
+            "ansi-regex": "^4.1.0"
+          }
+        },
+        "supports-color": {
+          "version": "5.5.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+          "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^3.0.0"
+          }
+        }
       }
     },
     "binary-extensions": {
@@ -11354,12 +11645,6 @@
         "find-up": "^4.0.0"
       }
     },
-    "platform": {
-      "version": "1.3.6",
-      "resolved": "https://registry.npmjs.org/platform/-/platform-1.3.6.tgz",
-      "integrity": "sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==",
-      "dev": true
-    },
     "plur": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/plur/-/plur-4.0.0.tgz",
@@ -12501,6 +12786,12 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/time-zone/-/time-zone-1.0.0.tgz",
       "integrity": "sha1-mcW/VZWJZq9tBtg73zgA3IL67F0=",
+      "dev": true
+    },
+    "tiny-human-time": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/tiny-human-time/-/tiny-human-time-1.2.0.tgz",
+      "integrity": "sha1-DEpCWUDgU+LTHZA9bwPTjPuXeGA=",
       "dev": true
     },
     "to-fast-properties": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,6 @@
     "destroy": "^1.0.4",
     "ee-first": "^1.1.1",
     "lodash.camelcase": "^4.3.0",
-    "lodash.concat": "^4.5.0",
     "lodash.forown": "^4.4.0",
     "lodash.isplainobject": "^4.0.6",
     "lodash.pick": "^4.4.0",
@@ -59,7 +58,7 @@
   },
   "devDependencies": {
     "@grpc/grpc-js": "^1.3.2",
-    "@grpc/proto-loader": "^0.6.1",
+    "@grpc/proto-loader": "^0.6.2",
     "async": "^3.2.0",
     "ava": "^3.15.0",
     "benchmarkify": "^2.1.3",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,6 @@
     "delegates": "^1.0.0",
     "destroy": "^1.0.4",
     "ee-first": "^1.1.1",
-    "grpc-create-metadata": "^4.0.0",
     "lodash.camelcase": "^4.3.0",
     "lodash.concat": "^4.5.0",
     "lodash.forown": "^4.4.0",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "nyc npm run linttest",
     "coverage": "nyc report --reporter=text-lcov > ./coverage/lcov.info",
     "apidocs": "jsdoc2md lib/*.js >  api2.md",
-    "docs": "jsdoc2md lib/*.js --heading-depth 3 | ./fixdocs > api.md"
+    "docs": "jsdoc2md lib/*.js --heading-depth 3 | ./fixdocs > api.md",
+    "benchmark": "node test/benchmark.js"
   },
   "repository": {
     "type": "git",
@@ -61,6 +62,7 @@
     "@grpc/proto-loader": "^0.6.1",
     "async": "^3.2.0",
     "ava": "^3.15.0",
+    "benchmark": "^2.1.4",
     "coveralls": "^3.1.0",
     "google-protobuf": "^3.17.3",
     "highland": "3.0.0-beta.10",

--- a/package.json
+++ b/package.json
@@ -62,7 +62,7 @@
     "@grpc/proto-loader": "^0.6.1",
     "async": "^3.2.0",
     "ava": "^3.15.0",
-    "benchmark": "^2.1.4",
+    "benchmarkify": "^2.1.3",
     "coveralls": "^3.1.0",
     "google-protobuf": "^3.17.3",
     "highland": "3.0.0-beta.10",

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -22,5 +22,14 @@ suite
     const app = new Mali()
     app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
   })
+  .add('mali.use', () => {
+    const app = new Mali()
+    app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
+    app.use({
+      SayHello: (ctx) => {
+        ctx.res = { message: `Hi ${ctx.name}!` }
+      }
+    })
+  })
   .on('cycle', (event) => console.log(event.target.toString()))
   .run({ async: true })

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,0 +1,20 @@
+const Benchmark = require('benchmark')
+const metaCreate = require('../lib/metadata')
+
+const suite = new Benchmark.Suite()
+
+const largeMetadata = {
+  hello: 'world',
+  maxSafe: Number.MAX_SAFE_INTEGER
+}
+
+for (let i = 0; i < 5000; i++) {
+  largeMetadata[`key-${i}`] = `value-${i}`
+}
+
+suite
+  .add('metadata.create', () => {
+    metaCreate(largeMetadata)
+  })
+  .on('cycle', (event) => console.log(event.target.toString()))
+  .run({ async: true })

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,5 +1,7 @@
 const Benchmark = require('benchmark')
 const metaCreate = require('../lib/metadata')
+const Mali = require('../lib/app')
+const path = require('path')
 
 const suite = new Benchmark.Suite()
 
@@ -15,6 +17,10 @@ for (let i = 0; i < 5000; i++) {
 suite
   .add('metadata.create', () => {
     metaCreate(largeMetadata)
+  })
+  .add('mali.addService', () => {
+    const app = new Mali()
+    app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
   })
   .on('cycle', (event) => console.log(event.target.toString()))
   .run({ async: true })

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -35,4 +35,10 @@ suite.add('mali.use', () => {
   })
 })
 
+suite.add('mali.use as global middleware', () => {
+  const app = new Mali()
+  app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
+  app.use((ctx, next) => next())
+})
+
 suite.run()

--- a/test/benchmark.js
+++ b/test/benchmark.js
@@ -1,9 +1,10 @@
-const Benchmark = require('benchmark')
+const Benchmark = require('benchmarkify')
 const metaCreate = require('../lib/metadata')
 const Mali = require('../lib/app')
 const path = require('path')
 
-const suite = new Benchmark.Suite()
+const benchmark = new Benchmark('Mali').printHeader()
+const suite = benchmark.createSuite('Functions')
 
 const largeMetadata = {
   hello: 'world',
@@ -18,18 +19,20 @@ suite
   .add('metadata.create', () => {
     metaCreate(largeMetadata)
   })
-  .add('mali.addService', () => {
-    const app = new Mali()
-    app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
+
+suite.add('mali.addService', () => {
+  const app = new Mali()
+  app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
+})
+
+suite.add('mali.use', () => {
+  const app = new Mali()
+  app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
+  app.use({
+    SayHello: (ctx) => {
+      ctx.res = { message: `Hi ${ctx.name}!` }
+    }
   })
-  .add('mali.use', () => {
-    const app = new Mali()
-    app.addService(path.join(__dirname, './protos/helloworld.proto'), 'Greeter')
-    app.use({
-      SayHello: (ctx) => {
-        ctx.res = { message: `Hi ${ctx.name}!` }
-      }
-    })
-  })
-  .on('cycle', (event) => console.log(event.target.toString()))
-  .run({ async: true })
+})
+
+suite.run()

--- a/test/metadata.create.test.js
+++ b/test/metadata.create.test.js
@@ -1,0 +1,34 @@
+const test = require('ava')
+const grpc = require('@grpc/grpc-js')
+const create = require('../lib/metadata')
+
+test('should return undefined if not-object', (t) => {
+  t.is(create('hello'), undefined)
+  t.is(create(undefined), undefined)
+})
+
+test('should return grpc.Metadata', (t) => {
+  const meta = new grpc.Metadata()
+  meta.set('hello', 'world')
+
+  const returned = create(meta)
+  t.truthy(returned instanceof grpc.Metadata)
+  t.deepEqual(meta.get('hello'), ['world'])
+})
+
+test('should handle buffers', (t) => {
+  const meta = create({ 'john-bin': Buffer.from('snow'), 'non-existing': null, john: [] }, { addEmpty: true })
+  t.deepEqual(meta.get('john-bin'), [Buffer.from('snow')])
+  t.deepEqual(meta.get('non-existing'), [])
+  t.deepEqual(meta.get('john'), [''])
+
+  const empty = create({ john: [] }, { addEmpty: false })
+  t.deepEqual(empty.get('john'), [])
+
+  try {
+    create({ john: Buffer.from('snow') })
+    t.fail()
+  } catch (error) {
+    t.is(error.message, 'Metadata key "john" should end with "-bin" since it has a non-string value.')
+  }
+})

--- a/test/metadata.create.test.js
+++ b/test/metadata.create.test.js
@@ -17,13 +17,10 @@ test('should return grpc.Metadata', (t) => {
 })
 
 test('should handle buffers', (t) => {
-  const meta = create({ 'john-bin': Buffer.from('snow'), 'non-existing': null, john: [] }, { addEmpty: true })
+  const meta = create({ 'john-bin': Buffer.from('snow'), 'non-existing': null, john: [] })
   t.deepEqual(meta.get('john-bin'), [Buffer.from('snow')])
   t.deepEqual(meta.get('non-existing'), [])
-  t.deepEqual(meta.get('john'), [''])
-
-  const empty = create({ john: [] }, { addEmpty: false })
-  t.deepEqual(empty.get('john'), [])
+  t.deepEqual(meta.get('john'), [])
 
   try {
     create({ john: Buffer.from('snow') })


### PR DESCRIPTION
I'm trying to reduce the boot time of Mali. There are lots of things to do, but most significant thing I've realized is that we need to remove lodash forOwn usage. Even changing it with a `for(const el in obj)` improves the performance a lot. This pull request creates a benchmark suite for addService and includes all the performance changes to reduce addService duration.

## Initial
```
> mali@0.43.1 benchmark
> node test/benchmark.js

metadata.create x 725 ops/sec ±0.19% (95 runs sampled)
mali.addService x 12,350 ops/sec ±3.70% (89 runs sampled)
mali.use x 12,727 ops/sec ±1.75% (90 runs sampled)
```
## Current
```
Platform info:
==============
   Darwin 20.5.0 arm64
   Node.JS: 16.2.0
   V8: 9.0.257.25-node.16
   Apple M1 × 8

Suite: Functions
✔ metadata.create                             747 rps
✔ mali.addService                          13,170 rps
✔ mali.use                                 13,259 rps
✔ mali.use as global middleware            13,559 rps

   metadata.create                     -94.49%            (747 rps)   (avg: 1ms)
   mali.addService                      -2.87%         (13,170 rps)   (avg: 75μs)
   mali.use                             -2.21%         (13,259 rps)   (avg: 75μs)
   mali.use as global middleware            0%         (13,559 rps)   (avg: 73μs)
-----------------------------------------------------------------------
```