### PR TITLE
fix: update type definition for `Mali.addService`

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ declare class Mali<T> extends EventEmitter implements App<T> {
   silent: boolean;
   context: T
 
-  addService (path: any, name: string | ReadonlyArray<string>, options?: any): void;
+  addService (path: any, name?: string | ReadonlyArray<string>, options?: any): void;
   use (service?: any, name?: any, fns?: any): void;
   start (port: number | string, creds?: any, options?: any): Promise<grpc.Server>;
   toJSON (): any;


### PR DESCRIPTION
This updates the Typescript type definition for the `addService` method in the `Mali` class.

The code accepts an optional parameter for the `name` argument (see https://github.com/malijs/mali/blob/b03c1b7cbc46cde7af3e6fc37f0cbba7aeaf0aa5/lib/app.js#L101) but the type definition doesn't reflect this.

Fixes #127 