### PR TITLE
Update locals typing to be indexable

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ declare namespace Mali {
     res: GrpcResponse;
     type: string;
     metadata: any;
-    locals: { [key: string]: any};
+    locals: Record<string, any>;
     get (field: string): any;
     set (field: any, val?: any): void;
     sendMetadata (md: any): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -47,7 +47,7 @@ declare namespace Mali {
     res: GrpcResponse;
     type: string;
     metadata: any;
-    locals: object;
+    locals: { [key: string]: any};
     get (field: string): any;
     set (field: any, val?: any): void;
     sendMetadata (md: any): void;


### PR DESCRIPTION
Currently you cant access any of the ctx.local's properties because it is just typed as `object`. This update makes any keys accessible.